### PR TITLE
feat: 글로벌 예외 처리

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/exception/custom/CustomException.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/custom/CustomException.java
@@ -1,0 +1,23 @@
+package com.campfiredev.growtogether.exception.custom;
+
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode; // 예외의 종류를 나타내는 ErrorCode Enum
+
+  private final String description; // 예외 상세 메시지
+
+  private final HttpStatus status; // HTTP 상태 코드
+
+  public CustomException(ErrorCode errorCode){
+    super(errorCode.getDescription());
+    this.errorCode = errorCode;
+    this.description = errorCode.getDescription();
+    this.status = errorCode.getStatus();
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.campfiredev.growtogether.exception.handler;
+
+import static com.campfiredev.growtogether.exception.response.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.campfiredev.growtogether.exception.response.ErrorCode.INVALID_INPUT_DATA;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * CustomException 처리 핸들러
+   * @param e 발생한 CustomException
+   * @return ErrorResponse
+   */
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    return ResponseEntity.status(e.getStatus()).body(new ErrorResponse(e.getErrorCode()));
+  }
+
+  /**
+   * @Valid 유효성 검사 실패 (MethodArgumentNotValidException) 처리 핸들러
+   * @param e 발생한 MethodArgumentNotValidException
+   * @return ErrorResponse (잘못된 입력 데이터 관련 에러 메시지 포함)
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+
+    String description = e.getBindingResult().getFieldErrors().stream()
+        .map(error -> error.getField() + ": " + error.getDefaultMessage())
+        .findFirst().orElse(INVALID_INPUT_DATA.getDescription());
+
+    return ResponseEntity.status(BAD_REQUEST)
+        .body(new ErrorResponse(INVALID_INPUT_DATA, description));
+  }
+
+  /**
+   * 예상하지 못한 예외(Exception) 처리 핸들러
+   * @param e 발생한 예외
+   * @return ErrorResponse
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    return ResponseEntity.status(INTERNAL_SERVER_ERROR.getStatus()).body(new ErrorResponse(INTERNAL_SERVER_ERROR));
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.campfiredev.growtogether.exception.response;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  //예외 생길 때마다 이런 식으로 추가
+  ALREADY_JOINED_STUDY("이미 참석 중인 스터디입니다.", BAD_REQUEST),
+
+  INVALID_INPUT_DATA("잘못된 입력 데이터입니다.", BAD_REQUEST),
+
+  INTERNAL_SERVER_ERROR("서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String description;
+
+  private final HttpStatus status;
+}
+

--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorResponse.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.campfiredev.growtogether.exception.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ErrorResponse {
+
+  private ErrorCode errorCode; // 에러 코드 (ErrorCode Enum)
+
+  private String description; // 상세 오류 메시지
+
+  private HttpStatus status; // HTTP 상태 코드
+
+  public ErrorResponse(ErrorCode errorCode){
+    this.errorCode = errorCode;
+    this.description = errorCode.getDescription();
+    this.status = errorCode.getStatus();
+  }
+
+  public ErrorResponse(ErrorCode errorCode, String description){
+    this.errorCode = errorCode;
+    this.description = description;
+    this.status = errorCode.getStatus();
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/exception/test/TestController.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/test/TestController.java
@@ -1,0 +1,29 @@
+package com.campfiredev.growtogether.exception.test;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 테스트용
+ */
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+  private final TestService testService;
+
+  @GetMapping("/custom-exception")
+  public ResponseEntity<String> throwCustomException() {
+    testService.throwCustomException("throw");
+    return ResponseEntity.ok("ok");
+  }
+
+  @GetMapping("/exception")
+  public ResponseEntity<String> throwException() throws IllegalAccessException {
+    testService.throwException("throw");
+    return ResponseEntity.ok("ok");
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/exception/test/TestService.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/test/TestService.java
@@ -1,0 +1,26 @@
+package com.campfiredev.growtogether.exception.test;
+
+import static com.campfiredev.growtogether.exception.response.ErrorCode.*;
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 테스트용
+ */
+@Service
+public class TestService {
+
+  public void throwCustomException(String a){
+    if(a.equals("throw")){
+      throw new CustomException(ALREADY_JOINED_STUDY);
+    }
+  }
+
+  public void throwException(String a) throws IllegalAccessException {
+    if(a.equals("throw")){
+      throw new IllegalAccessException();
+    }
+  }
+
+}

--- a/src/test/java/com/campfiredev/growtogether/exception/test/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/campfiredev/growtogether/exception/test/GlobalExceptionHandlerTest.java
@@ -1,0 +1,50 @@
+package com.campfiredev.growtogether.exception.test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GlobalExceptionHandlerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @SpyBean
+  private TestService testService;
+
+  @Test
+  @DisplayName("CustomException 발생 시 globalExceptionHandler 호출")
+  void testCustomExceptionHandling() throws Exception {
+
+    mockMvc.perform(get("/custom-exception")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("ALREADY_JOINED_STUDY"))
+        .andExpect(jsonPath("$.description").value("이미 참석 중인 스터디입니다."));
+  }
+
+  @Test
+  @DisplayName("Exception 발생 시 globalExceptionHandler 호출")
+  void testIllegalAccessExceptionHandling() throws Exception {
+
+    mockMvc.perform(get("/exception")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"))
+        .andExpect(jsonPath("$.description").value("서버 오류입니다."));
+  }
+}


### PR DESCRIPTION

## 📝 요약(Summary)
- CustomException 추가 (ErrorCode 기반 커스텀 예외)
- ErrorResponse 추가(일관된 에러 응답 구조)
- GlobalExceptionHandler 추가 (예외 처리 통합 관리)
- ErrorCode Enum 추가 (예외 코드 및 메시지 정의)
- 테스트 추가
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/11d69cc2-ea1d-4fb6-8be5-33004a992646)

## 💬 공유사항 to 리뷰어
- 현재 `GlobalExceptionHandler`에서는 아래 예외를 처리합니다.  
  1. `CustomException`  (커스텀 예외)
  2. `MethodArgumentNotValidException` (유효성 검사 실패)  
  3. `Exception` (기타 예상치 못한 예외)  

- 서비스 레이어에서 발생하는 예외는 **가능하면 `CustomException`을 활용**하는 것이 좋을 것 같습니다.  
  예를 들어, 이미 사용 중인 닉네임 예외를 처리하려면 다음과 같이 하면 됩니다.  

  **📌 예제: 닉네임 중복 예외 추가**  
  1. `ErrorCode` Enum에 추가  
     ```java
     DUPLICATE_NICKNAME("이미 사용 중인 닉네임입니다.", BAD_REQUEST);
     ```
  2. 서비스에서 예외 던지기  
     ```java
     throw new CustomException(DUPLICATE_NICKNAME);
     ```

- 추가하고 싶은 예외가 있을 시 말씀해 주시면 추가하도록 하겠습니다.
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->