### PR TITLE
feat : 일정 관리 구현

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
   STUDY_MEMBER_ONLY("참가 중인 사람만 투표할 수 있습니다.", BAD_REQUEST),
   VOTING_ALREADY_EXISTS("이미 투표하셨습니다.", BAD_REQUEST),
   VOTE_ALREADY_COMPLETE("이미 종료된 투표입니다.",BAD_REQUEST),
+  SCHEDULE_NOT_FOUND("존재하지 않는 일정입니다.",BAD_REQUEST),
+  NOT_AUTHOR("작성자가 아닙니다.",BAD_REQUEST),
+  CANNOT_DELETE_MAIN_SCHEDULE("메인 일정은 삭제할 수 없습니다.",HttpStatus.BAD_REQUEST),
 
 
   ALREADY_DELETED_STUDY("이미 삭제된 게시글 입니다.",BAD_REQUEST),

--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
   SCHEDULE_NOT_FOUND("존재하지 않는 일정입니다.",BAD_REQUEST),
   NOT_AUTHOR("작성자가 아닙니다.",BAD_REQUEST),
   CANNOT_DELETE_MAIN_SCHEDULE("메인 일정은 삭제할 수 없습니다.",HttpStatus.BAD_REQUEST),
+  ALREADY_EXISTS_SCHEDULE("겹치는 일정이 존재합니다.",BAD_REQUEST),
 
 
   ALREADY_DELETED_STUDY("이미 삭제된 게시글 입니다.",BAD_REQUEST),

--- a/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
@@ -26,7 +26,7 @@ public class JoinController {
    */
   @PostMapping("{id}/join")
   public void join(@PathVariable Long id) {
-    joinService.join(2L,id);
+    joinService.join(3L,id);
   }
 
   /**

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/LocalTimeConverter.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/LocalTimeConverter.java
@@ -1,0 +1,22 @@
+package com.campfiredev.growtogether.study.schedule;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Converter(autoApply = true)
+public class LocalTimeConverter implements AttributeConverter<LocalTime, String> {
+
+  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+  @Override
+  public String convertToDatabaseColumn(LocalTime time) {
+    return (time == null) ? null : time.format(FORMATTER);
+  }
+
+  @Override
+  public LocalTime convertToEntityAttribute(String dbData) {
+    return (dbData == null) ? null : LocalTime.parse(dbData, FORMATTER);
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/controller/ScheduleController.java
@@ -29,23 +29,38 @@ public class ScheduleController {
 
   private final ScheduleService scheduleService;
 
+  /**
+   * 일정 추가
+   * 로그인 이후 사용자 id도 넘길 예정
+   */
   @PostMapping("/{studyId}/schedule")
   public void createSchedule(@PathVariable Long studyId,
       @RequestBody @Valid ScheduleCreateDto scheduleCreateDto) {
     scheduleService.createSchedule(studyId, 1L, scheduleCreateDto);
   }
 
+  /**
+   * 일정 수정
+   * 로그인 이후 사용자 id도 넘길 예정
+   */
   @PutMapping("/schedule/{scheduleId}")
   public void updateSchedule(@PathVariable Long scheduleId,
       @RequestBody @Valid ScheduleUpdateDto scheduleUpdateDto) {
     scheduleService.updateSchedule(1L, scheduleId, scheduleUpdateDto);
   }
 
+  /**
+   * 일정 삭제
+   * 로그인 이후 사용자 id도 넘길 예정
+   */
   @DeleteMapping("/schedule/{scheduleId}")
   public void deleteSchedule(@PathVariable Long scheduleId) {
     scheduleService.deleteSchedule(1L, scheduleId);
   }
 
+  /**
+   * 해당일의 일정 리스트 조회
+   */
   @GetMapping("/{studyId}/schedule")
   public ResponseEntity<List<ScheduleDto>> getSchedule(@PathVariable Long studyId,
       @RequestParam(required = false) LocalDate date) {
@@ -55,6 +70,9 @@ public class ScheduleController {
     return ResponseEntity.ok(scheduleService.getSchedules(studyId, date));
   }
 
+  /**
+   * 해당 달의 일정 리스트 조회
+   */
   @GetMapping("/{studyId}/schedules")
   public ResponseEntity<ScheduleMonthDto> getSchedules(@PathVariable Long studyId,
       @RequestParam(required = false) String date) {

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/controller/ScheduleController.java
@@ -1,0 +1,66 @@
+package com.campfiredev.growtogether.study.schedule.controller;
+
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleCreateDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleMonthDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleUpdateDto;
+import com.campfiredev.growtogether.study.schedule.service.ScheduleService;
+import jakarta.ejb.Schedule;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study")
+public class ScheduleController {
+
+  private final ScheduleService scheduleService;
+
+  @PostMapping("/{studyId}/schedule")
+  public void createSchedule(@PathVariable Long studyId,
+      @RequestBody @Valid ScheduleCreateDto scheduleCreateDto) {
+    scheduleService.createSchedule(studyId, 1L, scheduleCreateDto);
+  }
+
+  @PutMapping("/schedule/{scheduleId}")
+  public void updateSchedule(@PathVariable Long scheduleId,
+      @RequestBody @Valid ScheduleUpdateDto scheduleUpdateDto) {
+    scheduleService.updateSchedule(1L, scheduleId, scheduleUpdateDto);
+  }
+
+  @DeleteMapping("/schedule/{scheduleId}")
+  public void deleteSchedule(@PathVariable Long scheduleId) {
+    scheduleService.deleteSchedule(1L, scheduleId);
+  }
+
+  @GetMapping("/{studyId}/schedule")
+  public ResponseEntity<List<ScheduleDto>> getSchedule(@PathVariable Long studyId,
+      @RequestParam(required = false) LocalDate date) {
+    if (date == null) {
+      date = LocalDate.now();
+    }
+    return ResponseEntity.ok(scheduleService.getSchedules(studyId, date));
+  }
+
+  @GetMapping("/{studyId}/schedules")
+  public ResponseEntity<ScheduleMonthDto> getSchedules(@PathVariable Long studyId,
+      @RequestParam(required = false) String date) {
+    if (date == null) {
+      date = String.valueOf(YearMonth.now());
+    }
+    return ResponseEntity.ok(scheduleService.getMonthSchedules(studyId, date));
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/dto/MainScheduleDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/dto/MainScheduleDto.java
@@ -1,0 +1,17 @@
+package com.campfiredev.growtogether.study.schedule.dto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+
+@Getter
+public class MainScheduleDto {
+  LocalDateTime startTime;
+  LocalDateTime endTime;
+
+  public MainScheduleDto(String date, String time, int total) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    this.startTime = LocalDateTime.parse(date + " " + time, formatter);
+    this.endTime = this.startTime.plusMinutes(total);
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleCreateDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleCreateDto.java
@@ -1,0 +1,26 @@
+package com.campfiredev.growtogether.study.schedule.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleCreateDto {
+
+  @NotBlank
+  private String title;
+
+  @NotNull
+  private LocalDate date;
+
+  @NotNull
+  private LocalTime time;
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleDto.java
@@ -1,0 +1,41 @@
+package com.campfiredev.growtogether.study.schedule.dto;
+
+import com.campfiredev.growtogether.study.schedule.entity.ScheduleEntity;
+import com.campfiredev.growtogether.study.schedule.type.ScheduleType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleDto {
+
+  private Long id;
+
+  private String title;
+
+  private LocalDate date;
+
+  private LocalTime time;
+
+  private ScheduleType scheduleType;
+
+  private String nickName;
+
+  public static ScheduleDto fromEntity(ScheduleEntity scheduleEntity) {
+    return ScheduleDto.builder()
+        .id(scheduleEntity.getId())
+        .title(scheduleEntity.getTitle())
+        .date(scheduleEntity.getDate())
+        .time(scheduleEntity.getTime())
+        .scheduleType(scheduleEntity.getType())
+        .nickName(scheduleEntity.getStudyMember().getMember().getNickName())
+        .build();
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleMonthDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleMonthDto.java
@@ -1,0 +1,31 @@
+package com.campfiredev.growtogether.study.schedule.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleMonthDto {
+  private List<ScheduleGroup> schedules;
+
+  public static ScheduleMonthDto from(Map<LocalDate, List<ScheduleDto>> groupedSchedules) {
+    List<ScheduleGroup> scheduleGroups = groupedSchedules.entrySet().stream()
+        .map(entry -> new ScheduleGroup(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+    return new ScheduleMonthDto(scheduleGroups);
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ScheduleGroup {
+    private LocalDate date;
+    private List<ScheduleDto> events;
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleUpdateDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/dto/ScheduleUpdateDto.java
@@ -1,5 +1,7 @@
-package com.campfiredev.growtogether.study.vote.dto;
+package com.campfiredev.growtogether.study.schedule.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -11,12 +13,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UpdateScheduleDto {
+public class ScheduleUpdateDto {
 
-  private String content;
+  @NotBlank
+  private String title;
 
+  @NotNull
   private LocalDate date;
 
+  @NotNull
   private LocalTime time;
 
 }

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/entity/ScheduleEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/entity/ScheduleEntity.java
@@ -1,0 +1,76 @@
+package com.campfiredev.growtogether.study.schedule.entity;
+
+import static com.campfiredev.growtogether.study.schedule.type.ScheduleType.*;
+
+import com.campfiredev.growtogether.study.entity.Study;
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import com.campfiredev.growtogether.study.schedule.LocalTimeConverter;
+import com.campfiredev.growtogether.study.schedule.type.ScheduleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "schedule")
+public class ScheduleEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "schedule_id")
+  private Long id;
+
+  @Column(nullable = false)
+  @Setter
+  private String title;
+
+  @Column(nullable = false)
+  @Setter
+  private LocalDate date;
+
+  @Column(nullable = false)
+  @Setter
+  private LocalTime time;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "study_member_id", nullable = false)
+  private StudyMemberEntity studyMember;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "study_id", nullable = false)
+  private Study study;
+
+  @Enumerated(EnumType.STRING)
+  private ScheduleType type;
+
+  public static ScheduleEntity create(StudyMemberEntity studyMember, String title, LocalDate date,
+      LocalTime time) {
+    return ScheduleEntity.builder()
+        .title(title)
+        .date(date)
+        .time(time)
+        .studyMember(studyMember)
+        .study(studyMember.getStudy())
+        .type(OTHER)
+        .build();
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,31 @@
+package com.campfiredev.growtogether.study.schedule.repository;
+
+import com.campfiredev.growtogether.study.schedule.entity.ScheduleEntity;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
+
+  @Query("SELECT sc FROM ScheduleEntity sc JOIN FETCH sc.studyMember sm "
+      + "JOIN FETCH sm.member m "
+      + "WHERE sc.study.studyId = :studyId AND sc.date = :date")
+  List<ScheduleEntity> findWithMemberByStudyIdAndDate(
+      @Param("studyId") Long studyId,
+      @Param("date") LocalDate date
+  );
+
+
+  @Query("SELECT sc FROM ScheduleEntity sc " +
+      "JOIN FETCH sc.studyMember sm " +
+      "JOIN FETCH sm.member m " +
+      "WHERE sc.study.studyId = :studyId " +
+      "AND sc.date BETWEEN :startDate AND :endDate")
+  List<ScheduleEntity> findWithMemberByStudyIdAndDateBetween(
+      @Param("studyId") Long studyId,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate
+  );
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/service/ScheduleService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/service/ScheduleService.java
@@ -1,0 +1,120 @@
+package com.campfiredev.growtogether.study.schedule.service;
+
+import static com.campfiredev.growtogether.exception.response.ErrorCode.*;
+import static com.campfiredev.growtogether.study.schedule.type.ScheduleType.MAIN;
+import static com.campfiredev.growtogether.study.type.StudyMemberType.LEADER;
+import static com.campfiredev.growtogether.study.type.StudyMemberType.NORMAL;
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import com.campfiredev.growtogether.study.repository.join.JoinRepository;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleCreateDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleMonthDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleUpdateDto;
+import com.campfiredev.growtogether.study.schedule.entity.ScheduleEntity;
+import com.campfiredev.growtogether.study.schedule.repository.ScheduleRepository;
+import com.campfiredev.growtogether.study.vote.service.VoteService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleService {
+
+  private final ScheduleRepository scheduleRepository;
+  private final JoinRepository joinRepository;
+  private final VoteService voteService;
+
+  public void createSchedule(Long studyId, Long memberId, ScheduleCreateDto scheduleCreateDto) {
+    StudyMemberEntity studyMemberEntity = getStudyMemberEntity(studyId, memberId);
+
+    scheduleRepository.save(ScheduleEntity.create(studyMemberEntity, scheduleCreateDto.getTitle(),
+        scheduleCreateDto.getDate(), scheduleCreateDto.getTime()));
+  }
+
+  public void updateSchedule(Long memberId, Long scheduleId, ScheduleUpdateDto scheduleUpdateDto) {
+    ScheduleEntity scheduleEntity = getScheduleEntity(scheduleId);
+
+    validateCreateVote(memberId, scheduleId, scheduleUpdateDto, scheduleEntity);
+
+    validateSameUser(memberId, scheduleEntity);
+
+    scheduleEntity.setTitle(scheduleUpdateDto.getTitle());
+    scheduleEntity.setDate(scheduleUpdateDto.getDate());
+    scheduleEntity.setTime(scheduleUpdateDto.getTime());
+  }
+
+
+  public void deleteSchedule(Long memberId, Long scheduleId) {
+    ScheduleEntity scheduleEntity = getScheduleEntity(scheduleId);
+
+    if(MAIN.equals(scheduleEntity.getType())){
+      throw new CustomException(CANNOT_DELETE_MAIN_SCHEDULE);
+    }
+
+    validateSameUser(memberId, scheduleEntity);
+
+    scheduleRepository.delete(scheduleEntity);
+  }
+
+  public List<ScheduleDto> getSchedules(Long studyId, LocalDate date) {
+    return scheduleRepository.findWithMemberByStudyIdAndDate(studyId, date).stream()
+        .map(entity -> ScheduleDto.fromEntity(entity))
+        .collect(Collectors.toList());
+  }
+
+  public ScheduleMonthDto getMonthSchedules(Long studyId, String date) {
+    YearMonth yearMonth = YearMonth.parse(date);
+
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+
+    Map<LocalDate, List<ScheduleDto>> collect = scheduleRepository.findWithMemberByStudyIdAndDateBetween(
+            studyId, startDate, endDate)
+        .stream()
+        .map(scheduleEntity -> ScheduleDto.fromEntity(scheduleEntity))
+        .collect(Collectors.groupingBy(scheduleDto -> scheduleDto.getDate()));
+
+    return ScheduleMonthDto.from(collect);
+  }
+
+  private void validateCreateVote(Long memberId, Long scheduleId, ScheduleUpdateDto scheduleUpdateDto,
+      ScheduleEntity scheduleEntity) {
+    if (MAIN.equals(scheduleEntity.getType()) && (
+        !scheduleEntity.getDate().equals(scheduleUpdateDto.getDate()) || !scheduleEntity.getTime()
+            .equals(scheduleUpdateDto.getTime()))) {
+      voteService.createChangeVote(memberId, scheduleEntity.getStudy().getStudyId(), scheduleId,
+          scheduleUpdateDto);
+    }
+  }
+
+  private void validateSameUser(Long memberId, ScheduleEntity scheduleEntity) {
+    StudyMemberEntity studyMemberEntity = getStudyMemberEntity(memberId,
+        scheduleEntity.getStudy().getStudyId());
+
+    if(!memberId.equals(studyMemberEntity.getId())) {
+      throw new CustomException(NOT_AUTHOR);
+    }
+  }
+
+  private StudyMemberEntity getStudyMemberEntity(Long studyId, Long memberId) {
+    return joinRepository.findByMemberIdAndStudyIdInStatus(memberId,
+            studyId, List.of(LEADER, NORMAL))
+        .orElseThrow(() -> new CustomException(NOT_A_STUDY_MEMBER));
+  }
+
+  private ScheduleEntity getScheduleEntity(Long scheduleId) {
+    return scheduleRepository.findById(scheduleId)
+        .orElseThrow(() -> new CustomException(SCHEDULE_NOT_FOUND));
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/schedule/type/ScheduleType.java
+++ b/src/main/java/com/campfiredev/growtogether/study/schedule/type/ScheduleType.java
@@ -1,0 +1,7 @@
+package com.campfiredev.growtogether.study.schedule.type;
+
+public enum ScheduleType {
+
+  MAIN, OTHER
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/vote/controller/VoteController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/controller/VoteController.java
@@ -1,6 +1,6 @@
 package com.campfiredev.growtogether.study.vote.controller;
 
-import com.campfiredev.growtogether.study.vote.dto.UpdateScheduleDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleUpdateDto;
 import com.campfiredev.growtogether.study.vote.dto.VotingDto;
 import com.campfiredev.growtogether.study.vote.dto.VoteCreateDto;
 import com.campfiredev.growtogether.study.vote.dto.VoteDto;
@@ -31,7 +31,7 @@ public class VoteController {
    */
   @PostMapping("/vote/{voteId}")
   public void vote(@PathVariable Long voteId, @RequestBody @Valid VotingDto votingDto) {
-    voteService.vote(1L, voteId, votingDto);
+    voteService.vote(2L, voteId, votingDto);
   }
 
   /**
@@ -55,8 +55,8 @@ public class VoteController {
   //임시 테스트용
   @PostMapping("/{studyId}/change_vote")
   public void createChangeVote(@PathVariable Long studyId,
-      @RequestBody @Valid UpdateScheduleDto updateScheduleDto) {
-    voteService.createChangeVote(1L, studyId, 1L, updateScheduleDto);
+      @RequestBody @Valid ScheduleUpdateDto scheduleUpdateDto) {
+    voteService.createChangeVote(1L, studyId, 1L, scheduleUpdateDto);
   }
 
 }

--- a/src/main/java/com/campfiredev/growtogether/study/vote/controller/VoteController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/controller/VoteController.java
@@ -31,7 +31,7 @@ public class VoteController {
    */
   @PostMapping("/vote/{voteId}")
   public void vote(@PathVariable Long voteId, @RequestBody @Valid VotingDto votingDto) {
-    voteService.vote(2L, voteId, votingDto);
+    voteService.vote(3L, voteId, votingDto);
   }
 
   /**

--- a/src/main/java/com/campfiredev/growtogether/study/vote/entity/ChangeVoteEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/entity/ChangeVoteEntity.java
@@ -29,9 +29,10 @@ public class ChangeVoteEntity extends VoteEntity {
   private LocalTime time;
 
   public static ChangeVoteEntity create(String title, StudyMemberEntity studyMemberEntity,
-      String content, LocalDate date, LocalTime time) {
+      String content, LocalDate date, LocalTime time, Long scheduleId) {
     return ChangeVoteEntity.builder()
         .title(title)
+        .scheduleId(scheduleId)
         .studyMember(studyMemberEntity)
         .study(studyMemberEntity.getStudy())
         .status(PROGRESS)

--- a/src/main/java/com/campfiredev/growtogether/study/vote/service/ChangeVoteProcessor.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/service/ChangeVoteProcessor.java
@@ -1,14 +1,23 @@
 package com.campfiredev.growtogether.study.vote.service;
 
+import com.amazonaws.services.kms.model.CloudHsmClusterInUseException;
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import com.campfiredev.growtogether.study.schedule.entity.ScheduleEntity;
+import com.campfiredev.growtogether.study.schedule.repository.ScheduleRepository;
 import com.campfiredev.growtogether.study.vote.entity.ChangeVoteEntity;
 import com.campfiredev.growtogether.study.vote.entity.VoteEntity;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class ChangeVoteProcessor implements VoteProcessor {
+
+  private final ScheduleRepository scheduleRepository;
 
   //임시 테스트용
   @Override
@@ -18,6 +27,13 @@ public class ChangeVoteProcessor implements VoteProcessor {
       ChangeVoteEntity changeVoteEntity = (ChangeVoteEntity) voteEntity;
       log.info("CHANGE 투표 통과: " + changeVoteEntity.getDate());
       log.info("시간 변경: " + changeVoteEntity.getTime());
+
+      ScheduleEntity scheduleEntity = scheduleRepository.findById(changeVoteEntity.getScheduleId())
+          .orElseThrow(() -> new CustomException(ErrorCode.SCHEDULE_NOT_FOUND));
+
+      scheduleEntity.setTitle(changeVoteEntity.getContent());
+      scheduleEntity.setDate(changeVoteEntity.getDate());
+      scheduleEntity.setTime(changeVoteEntity.getTime());
     }
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/vote/service/KickVoteProcessor.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/service/KickVoteProcessor.java
@@ -8,19 +8,17 @@ import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
 import com.campfiredev.growtogether.study.repository.join.JoinRepository;
 import com.campfiredev.growtogether.study.vote.entity.KickVoteEntity;
 import com.campfiredev.growtogether.study.vote.entity.VoteEntity;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class KickVoteProcessor implements VoteProcessor {
 
   private final JoinRepository joinRepository;
-
-  public KickVoteProcessor(JoinRepository joinRepository) {
-    this.joinRepository = joinRepository;
-  }
 
   @Override
   @Transactional

--- a/src/main/java/com/campfiredev/growtogether/study/vote/service/VoteService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/service/VoteService.java
@@ -13,7 +13,7 @@ import com.campfiredev.growtogether.study.repository.join.JoinRepository;
 import com.campfiredev.growtogether.study.vote.ChangeVoteJob;
 import com.campfiredev.growtogether.study.vote.KickVoteJob;
 import com.campfiredev.growtogether.study.vote.SchedulerService;
-import com.campfiredev.growtogether.study.vote.dto.UpdateScheduleDto;
+import com.campfiredev.growtogether.study.schedule.dto.ScheduleUpdateDto;
 import com.campfiredev.growtogether.study.vote.dto.VotingDto;
 import com.campfiredev.growtogether.study.vote.dto.VoteCreateDto;
 import com.campfiredev.growtogether.study.vote.dto.VoteDto;
@@ -65,14 +65,14 @@ public class VoteService {
   }
 
   public void createChangeVote(Long memberId, Long studyId, Long scheduleId,
-      UpdateScheduleDto updateScheduleDto) {
+      ScheduleUpdateDto scheduleUpdateDto) {
     StudyMemberEntity studyMemberEntity = getStudyMemberEntity(memberId, studyId);
 
     String title = scheduleId + "번 스케줄 시간 변경 투표입니다.";
 
     ChangeVoteEntity save = changeVoteRepository.save(
-        ChangeVoteEntity.create(title, studyMemberEntity, updateScheduleDto.getContent(),
-            updateScheduleDto.getDate(), updateScheduleDto.getTime()));
+        ChangeVoteEntity.create(title, studyMemberEntity, scheduleUpdateDto.getTitle(),
+            scheduleUpdateDto.getDate(), scheduleUpdateDto.getTime()));
 
     scheduleJob(ChangeVoteJob.class, "changeJob", "changeGroup", 3, save.getId());
   }

--- a/src/main/java/com/campfiredev/growtogether/study/vote/service/VoteService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/vote/service/VoteService.java
@@ -72,7 +72,7 @@ public class VoteService {
 
     ChangeVoteEntity save = changeVoteRepository.save(
         ChangeVoteEntity.create(title, studyMemberEntity, scheduleUpdateDto.getTitle(),
-            scheduleUpdateDto.getDate(), scheduleUpdateDto.getTime()));
+            scheduleUpdateDto.getDate(), scheduleUpdateDto.getTime(), scheduleId));
 
     scheduleJob(ChangeVoteJob.class, "changeJob", "changeGroup", 3, save.getId());
   }


### PR DESCRIPTION

## 📝 요약(Summary)
- 일정 생성(OTHER 일정만)
- 일정 수정
- 일정 삭제
- 해당일의 일정 조회
- 해당달의 일정 조회
- 스터디 생성 시 메인 일정 자동 추가
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
일정을 MAIN 과 OTHER 로 나눴습니다.
MAIN 일정은 스터디 생성 시 자동으로 일정에 추가되도록 하고 이후 생성과 삭제는 불가능하게 했습니다.
MAIN 일정 날짜 수정 시 투표가 열리고 만장일치 시 변경되도록 하였습니다.
해당일의 일정 조회는 2025-03-01 이런 형식으로 날짜가 들어오면 해당 일의 일정을 전부 조회해서 리턴합니다.
해당달의 일정 조회는 2025-03 이 형식으로 들어오면 해당 달의 모든 일정을 날짜별로 그룹핑 해서 리턴합니다.

@Oh-Myeongjae 
MAIN 일정 자동 생성에 경우 스터디 생성 시에 createMainSchedule 메서드를 호출해 주시면 될 것 같습니다.
MainScheduleDto 만들어 놨으니  리스트 만들어서 파라미터로 넘겨 주시면 될 것 같습니다.
스터디 생성 시 날짜, 시간을 어떤 형식으로 받을지 모르겠는데 만약 date(2025-03-20), time(17:30) 이 형식으로 각각 받는다면 MainScheduleDto 생성자에 변환 로직 넣어놨으니 사용하시면 될 것 같고 LocalDateTime(2025-03-20 17:30) 이런 형식으로 바로 받으시면 그냥 MainScheduleDto에 바로 넣어서 createMainSchdule 메서드에 넘기면 될 것 같습니다.
자세한 내용은 코드 참조 바랍니다.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->