### PR TITLE
feat(SSE): SSE 실시간 알림

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/common/config/AmazonS3Config.java
+++ b/src/main/java/com/campfiredev/growtogether/common/config/AmazonS3Config.java
@@ -20,19 +20,18 @@ import org.springframework.stereotype.Component;
 public class AmazonS3Config {
     private final Credentials credentials;
 
-    @Value("${cloud.aws.region}")
-    private String region;
+
 
     @Bean
     public AmazonS3 amazonS3() {
-        if (credentials.accessKey == null || credentials.secretKey == null || region == null) {
+        if (credentials.accessKey == null || credentials.secretKey == null || credentials.region == null) {
             throw new IllegalArgumentException("AWS Access Key, Secret Key 또는 Region이 설정되지 않았습니다.");
         }
 
         BasicAWSCredentials awsCreds = new BasicAWSCredentials(credentials.accessKey, credentials.secretKey);
 
         return AmazonS3ClientBuilder.standard()
-                .withRegion(Regions.fromName(region))
+                .withRegion(Regions.fromName(credentials.region))
                 .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
     }
@@ -45,5 +44,8 @@ public class AmazonS3Config {
 
         @Value("${cloud.aws.credentials.secret-key}")
         private String secretKey;
+
+        @Value("${cloud.aws.credentials.region}")
+        private String region;
     }
 }

--- a/src/main/java/com/campfiredev/growtogether/common/config/AmazonS3Config.java
+++ b/src/main/java/com/campfiredev/growtogether/common/config/AmazonS3Config.java
@@ -20,16 +20,19 @@ import org.springframework.stereotype.Component;
 public class AmazonS3Config {
     private final Credentials credentials;
 
+    @Value("${cloud.aws.region}")
+    private String region;
+
     @Bean
     public AmazonS3 amazonS3() {
-        if (credentials.accessKey == null || credentials.secretKey == null || credentials.region == null) {
+        if (credentials.accessKey == null || credentials.secretKey == null || region == null) {
             throw new IllegalArgumentException("AWS Access Key, Secret Key 또는 Region이 설정되지 않았습니다.");
         }
 
         BasicAWSCredentials awsCreds = new BasicAWSCredentials(credentials.accessKey, credentials.secretKey);
 
         return AmazonS3ClientBuilder.standard()
-                .withRegion(Regions.fromName(credentials.region))
+                .withRegion(Regions.fromName(region))
                 .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
     }
@@ -42,9 +45,5 @@ public class AmazonS3Config {
 
         @Value("${cloud.aws.credentials.secret-key}")
         private String secretKey;
-
-        @Value("${cloud.aws.credentials.region}")
-        private String region;
-
     }
 }

--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -52,7 +52,9 @@ public enum ErrorCode {
 
   COMMENT_NOT_FOUND("존재하지 않은 댓글입니다.",BAD_REQUEST),
 
-  COMMENT_ACCESS_DENIED("해당 댓글에 접근 권한이 없습니다.",BAD_REQUEST);
+  COMMENT_ACCESS_DENIED("해당 댓글에 접근 권한이 없습니다.",BAD_REQUEST),
+
+  NOTI_NOT_FOUND("해당 알림을 찾을 수 없습니다.",BAD_REQUEST);
 
   private final String description;
 

--- a/src/main/java/com/campfiredev/growtogether/notification/controller/SseNotiContoller.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/controller/SseNotiContoller.java
@@ -1,0 +1,58 @@
+package com.campfiredev.growtogether.notification.controller;
+
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import com.campfiredev.growtogether.member.repository.MemberRepository;
+import com.campfiredev.growtogether.notification.service.NotificationService;
+import com.campfiredev.growtogether.notification.type.NotiType;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sse")
+public class SseNotiContoller {
+
+    private final NotificationService notificationService;
+    private final MemberRepository memberRepository;
+
+
+    @GetMapping(value = "/subscribe/{userId}",produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable Long userId, HttpServletResponse response){
+        try {
+            response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"); // 모든 오리진 허용
+            response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS");
+            response.setHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "Content-Type");
+            //cors 문제 발생으로 인한 헤더 설정 추가
+            return notificationService.subscribe(userId);
+        } catch (Exception e) {
+            log.error("SSE 구독 중 오류 발생 : {} ", e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Headers - Key : Accept Value: text/event-stream
+     * @param id
+     */
+    @PostMapping("/send-data/{id}")
+    public void sendData(@PathVariable Long id){
+        String msg = "Noti test sendData " + id;
+
+        MemberEntity member = memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        notificationService.sendNotification(member,msg, NotiType.BOOTCAMP);
+    }
+
+
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/dto/NotificationDto.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/dto/NotificationDto.java
@@ -1,0 +1,17 @@
+package com.campfiredev.growtogether.notification.dto;
+
+import com.campfiredev.growtogether.notification.type.NotiType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDto {
+
+    private String content;
+    private NotiType type;
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/entity/Notification.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/entity/Notification.java
@@ -1,0 +1,39 @@
+package com.campfiredev.growtogether.notification.entity;
+
+import com.campfiredev.growtogether.common.entity.BaseEntity;
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import com.campfiredev.growtogether.notification.type.NotiType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notiId;
+
+    @Column(nullable = false)
+    private boolean isCheck;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotiType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id",nullable = false)
+    private MemberEntity member;
+
+    public void markAsRead(){
+        this.isCheck = true;
+    }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/repository/EmitterRepository.java
@@ -1,0 +1,28 @@
+package com.campfiredev.growtogether.notification.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+public interface EmitterRepository {
+
+    /**
+     * sse 구독 요청이 오면 save를 통해서 저장
+     */
+    void save(Long userId, SseEmitter emitter);
+
+    /**
+     * 연결이 끊이면 delete를 통해서 제거
+     */
+    void delete(Long userId, SseEmitter emitter);
+
+    /**
+     *  특정 사용자에게 알림을 보낼 때 findByUserId를 통해서 Emitter 조회
+     */
+    List<SseEmitter> findByUserId(Long userId);
+
+    /**
+     * 특정 사용자 관련하여 모든 연결 삭제
+     */
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/repository/Impl/EmiiterRepositoryImpl.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/repository/Impl/EmiiterRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.campfiredev.growtogether.notification.repository.Impl;
+
+import com.campfiredev.growtogether.notification.repository.EmitterRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class EmiiterRepositoryImpl implements EmitterRepository {
+
+    private final Map<Long,List<SseEmitter>> sseEmitters = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Long userId, SseEmitter emitter) {
+        sseEmitters.computeIfAbsent(userId , k -> new ArrayList<>()).add(emitter);
+    }
+
+    @Override
+    public void delete(Long userId, SseEmitter emitter) {
+        List<SseEmitter> emitters = sseEmitters.get(userId);
+
+        if(emitter != null){
+            emitters.remove(emitter);
+            if(emitters.isEmpty()){
+                sseEmitters.remove(userId);
+            }
+        }
+    }
+
+    @Override
+    public List<SseEmitter> findByUserId(Long userId) {
+        return sseEmitters.getOrDefault(userId,new ArrayList<>());
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        sseEmitters.remove(userId);
+    }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/repository/NotificationRepository.java
@@ -1,0 +1,17 @@
+package com.campfiredev.growtogether.notification.repository;
+
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import com.campfiredev.growtogether.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification , Long> {
+
+    // 특정 사용자 읽지 않는 알림 조회
+    List<Notification> findByMemberAndIsCheckFalse(MemberEntity member);
+
+
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/service/Impl/NotificationServiceImpl.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/service/Impl/NotificationServiceImpl.java
@@ -1,0 +1,161 @@
+package com.campfiredev.growtogether.notification.service.Impl;
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import com.campfiredev.growtogether.notification.dto.NotificationDto;
+import com.campfiredev.growtogether.notification.entity.Notification;
+import com.campfiredev.growtogether.notification.repository.EmitterRepository;
+import com.campfiredev.growtogether.notification.repository.NotificationRepository;
+import com.campfiredev.growtogether.notification.service.NotificationService;
+import com.campfiredev.growtogether.notification.type.NotiType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final EmitterRepository emitterRepository;
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 60분 타임 아웃
+
+    /**
+     * 클라이언트가 SSE(Server - Sent Events) 알림을 구독하기 위해 호출하는 메서드
+     * @param userId
+     * @return
+     */
+    @Override
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = createEmitter(userId);
+
+        // 클라이언트가 처음 구독할 때 기본 메시지 전송 (연결 안정성 확보)
+        sendToClient(userId, "Connected to SSE stream. [userId=" + userId + "]");
+
+        return emitter;
+    }
+
+    /**
+     * 특정 사용사에게 알림을 전송 , 중요 알림 DB에 저장
+     * @param member 알림을 받을 사용자
+     * @param content 알림 내용
+     * @param type 알림 유형
+     */
+    @Override
+    public void sendNotification(MemberEntity member, String content, NotiType type) {
+        // SSE 실시간 알림 전송
+        notifyUser(member.getMemberId(), new NotificationDto(content, type));
+
+        // 중요 알림만 DB에 저장
+        if (importNoti(type)) {
+            Notification notification = Notification.builder()
+                    .member(member)
+                    .content(content)
+                    .isCheck(false)
+                    .type(type)
+                    .build();
+
+            notificationRepository.save(notification);
+        }
+    }
+
+    /**
+     * 사용자의 읽지 않은 알림 목록 조회
+     * @param member 알림을 조회할 사용자
+     * @return 읽지 않는 알림 리스트
+     */
+    @Override
+    public List<Notification> getUnReadNotifiactions(MemberEntity member) {
+        return notificationRepository.findByMemberAndIsCheckFalse(member);
+    }
+
+    /**
+     * 특정 알림 읽음 처리
+     * @param notiId
+     */
+    @Override
+    public void markNotification(Long notiId) {
+        Notification notification = notificationRepository.findById(notiId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTI_NOT_FOUND));
+
+        notification.markAsRead();
+        notificationRepository.save(notification);
+    }
+
+    /**
+     * 특정 사용자에게 SSE를 통한 알림 전송
+     * @param userId 알림을 받을 사용자 id
+     * @param notification 전송할 알림 데이터
+     */
+    private void notifyUser(Long userId, NotificationDto notification) {
+        List<SseEmitter> emitters = emitterRepository.findByUserId(userId);
+        List<SseEmitter> failEmitterList = new ArrayList<>();
+
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event().name("SSE").data(notification).reconnectTime(3000));
+            } catch (IOException e) {
+                emitter.complete();
+                failEmitterList.add(emitter);
+                log.error("Failed to send SSE event: {} ", e.getMessage());
+            }
+        });
+
+        failEmitterList.forEach(emitter -> emitterRepository.delete(userId, emitter));
+    }
+
+    /**
+     * 클라이언트에게 데이터를 전송 (전송이 잘되는지 확인을 위한 테스트 메서드)
+     *
+     * @param id   - 데이터를 받을 사용자의 아이디.
+     * @param data - 전송할 데이터.
+     */
+    private void sendToClient(Long id, Object data) {
+        List<SseEmitter> emitters = emitterRepository.findByUserId(id);
+        List<SseEmitter> failedEmitters = new ArrayList<>();
+
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .id(String.valueOf(id))
+                        .name("SSE first Connection")
+                        .data(data));
+            } catch (IOException e) {
+
+                emitter.completeWithError(e);
+                failedEmitters.add(emitter);
+                log.error("Failed to send data to SSE client: {} ", e.getMessage());
+            }
+        });
+
+        failedEmitters.forEach(emitter -> emitterRepository.delete(id, emitter));
+    }
+
+    /**
+     * 사용자 아이디를 기반으로 이벤트 Emitter를 생성
+     *
+     * @param id - 사용자 아이디.
+     * @return SseEmitter - 생성된 이벤트 Emitter.
+     */
+    private SseEmitter createEmitter(Long id) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(id, emitter);
+
+        // Emitter가 완료되거나 타임아웃되면 삭제
+        emitter.onCompletion(() -> emitterRepository.deleteAllByUserId(id));
+        emitter.onTimeout(() -> emitterRepository.deleteAllByUserId(id));
+
+        return emitter;
+    }
+
+    private boolean importNoti(NotiType type) {
+        return type.importNoti();
+    }
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/service/NotificationService.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/service/NotificationService.java
@@ -1,0 +1,23 @@
+package com.campfiredev.growtogether.notification.service;
+
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import com.campfiredev.growtogether.notification.entity.Notification;
+import com.campfiredev.growtogether.notification.type.NotiType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+public interface NotificationService {
+
+    //sse 구독
+    SseEmitter subscribe(Long userId);
+
+    //알림 전송
+    void sendNotification(MemberEntity member, String content, NotiType type);
+
+    // 읽지 않는 알림 조회
+    List<Notification> getUnReadNotifiactions(MemberEntity member);
+
+    //알림 읽음 처리
+    void markNotification(Long notiId);
+}

--- a/src/main/java/com/campfiredev/growtogether/notification/type/NotiType.java
+++ b/src/main/java/com/campfiredev/growtogether/notification/type/NotiType.java
@@ -1,0 +1,17 @@
+package com.campfiredev.growtogether.notification.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum NotiType {
+
+    BOOTCAMP(true),
+    STUDY(true),
+    VOTE(true);
+
+    private final boolean importType;
+
+    public boolean importNoti(){
+        return importType;
+    }
+}


### PR DESCRIPTION
- SSE(Server-Sent Events) 기반의 실시간 알림 기능 구현

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- SSE 기반의 실시간 알림 기능 추가
- 사용자 SSE 구독 기능 (`/sse/subscribe/{userId}`) 구현
- 특정 사용자에게 알림 전송 (`notificationService.sendNotification`)
- Emitter 관리 로직 (`NotificationServiceImpl`) 추가
- CORS 문제로 인한  (Response Header 추가)
- 중요 알림은 DB에 저장하여 유지

** 재연결 부분의 코드는 프론트 js에서 필요 ** 
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2b3f6e23-2311-4a8b-8dde-f09656b2891f)## 💬 공유사항 to 리뷰어
@focandlol @Oh-Myeongjae @try3982 
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->