### PR TITLE
feat: 출석

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -24,8 +25,10 @@ public enum ErrorCode {
   VOTE_ALREADY_COMPLETE("이미 종료된 투표입니다.",BAD_REQUEST),
   SCHEDULE_NOT_FOUND("존재하지 않는 일정입니다.",BAD_REQUEST),
   NOT_AUTHOR("작성자가 아닙니다.",BAD_REQUEST),
-  CANNOT_DELETE_MAIN_SCHEDULE("메인 일정은 삭제할 수 없습니다.",HttpStatus.BAD_REQUEST),
+  CANNOT_DELETE_MAIN_SCHEDULE("메인 일정은 삭제할 수 없습니다.", BAD_REQUEST),
   ALREADY_EXISTS_SCHEDULE("겹치는 일정이 존재합니다.",BAD_REQUEST),
+  INVALID_ATTENDANCE_TIME("출석 가능 시간이 아닙니다.", BAD_REQUEST),
+  ALREADY_ATTENDANCE("이미 출석했습니다.",BAD_REQUEST),
 
   // 파일 업로드 관련 예외
   FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/campfiredev/growtogether/study/controller/attendance/AttendanceController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/attendance/AttendanceController.java
@@ -1,0 +1,39 @@
+package com.campfiredev.growtogether.study.controller.attendance;
+
+import com.campfiredev.growtogether.study.dto.attendance.AttendanceDto;
+import com.campfiredev.growtogether.study.service.attendance.AttendanceService;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study")
+public class AttendanceController {
+
+  private final AttendanceService attendanceService;
+
+  /**
+   * 로그인 구현되면 사용자 정보 넘길 예정
+   * @param studyId
+   */
+  @PostMapping("/{studyId}/attendance")
+  public void attendance(@PathVariable Long studyId){
+    attendanceService.attendance(1L, studyId);
+  }
+
+  @GetMapping("/{studyId}/attendance")
+  public List<AttendanceDto> getAttendees(@PathVariable Long studyId, @RequestParam(required = false) String date){
+    if(date == null){
+      date = String.valueOf(YearMonth.now());
+    }
+    return attendanceService.getAttendee(studyId, date);
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/controller/schedule/ScheduleController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/schedule/ScheduleController.java
@@ -1,5 +1,7 @@
 package com.campfiredev.growtogether.study.controller.schedule;
 
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleAttendeeDto;
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleAttendeeMonthDto;
 import com.campfiredev.growtogether.study.dto.schedule.ScheduleCreateDto;
 import com.campfiredev.growtogether.study.dto.schedule.ScheduleDto;
 import com.campfiredev.growtogether.study.dto.schedule.ScheduleMonthDto;
@@ -29,8 +31,7 @@ public class ScheduleController {
   private final ScheduleService scheduleService;
 
   /**
-   * 일정 추가
-   * 로그인 이후 사용자 id도 넘길 예정
+   * 일정 추가 로그인 이후 사용자 id도 넘길 예정
    */
   @PostMapping("/{studyId}/schedule")
   public void createSchedule(@PathVariable Long studyId,
@@ -39,8 +40,7 @@ public class ScheduleController {
   }
 
   /**
-   * 일정 수정
-   * 로그인 이후 사용자 id도 넘길 예정
+   * 일정 수정 로그인 이후 사용자 id도 넘길 예정
    */
   @PutMapping("/schedule/{scheduleId}")
   public void updateSchedule(@PathVariable Long scheduleId,
@@ -49,8 +49,7 @@ public class ScheduleController {
   }
 
   /**
-   * 일정 삭제
-   * 로그인 이후 사용자 id도 넘길 예정
+   * 일정 삭제 로그인 이후 사용자 id도 넘길 예정
    */
   @DeleteMapping("/schedule/{scheduleId}")
   public void deleteSchedule(@PathVariable Long scheduleId) {
@@ -79,5 +78,20 @@ public class ScheduleController {
       date = String.valueOf(YearMonth.now());
     }
     return ResponseEntity.ok(scheduleService.getMonthSchedules(studyId, date));
+  }
+
+  /**
+   * 해당 달의 일정 + 일정별 출석자 같이 조회
+   * @param studyId
+   * @param date
+   * @return
+   */
+  @GetMapping("/{studyId}/schedules_attendee")
+  public ResponseEntity<ScheduleAttendeeMonthDto> getScheduleAttendee(@PathVariable Long studyId,
+      @RequestParam(required = false) String date){
+    if (date == null) {
+      date = String.valueOf(YearMonth.now());
+    }
+    return ResponseEntity.ok(scheduleService.getMonthSchedulesAttendees(studyId, date));
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/dto/attendance/AttendanceDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/attendance/AttendanceDto.java
@@ -1,0 +1,20 @@
+package com.campfiredev.growtogether.study.dto.attendance;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AttendanceDto {
+  private Long scheduleId;
+  private LocalDate date;
+  private LocalTime time;
+  private List<String> attendees;
+}

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeDto.java
@@ -4,6 +4,7 @@ import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
 import com.campfiredev.growtogether.study.type.ScheduleType;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,29 +14,25 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ScheduleDto {
+public class ScheduleAttendeeDto {
 
   private Long scheduleId;
-
   private String title;
-
   private LocalDate date;
-
   private LocalTime time;
-
-  private ScheduleType scheduleType;
-
+  private ScheduleType type;
   private String creator;
+  private List<String> attendedNicknames;
 
-  public static ScheduleDto fromEntity(ScheduleEntity scheduleEntity) {
-    return ScheduleDto.builder()
-        .scheduleId(scheduleEntity.getId())
-        .title(scheduleEntity.getTitle())
-        .date(scheduleEntity.getDate())
-        .time(scheduleEntity.getTime())
-        .scheduleType(scheduleEntity.getType())
-        .creator(scheduleEntity.getStudyMember().getMember().getNickName())
+  public static ScheduleAttendeeDto create(ScheduleEntity schedule, String nickName, List<String> attendedNicknames) {
+    return ScheduleAttendeeDto.builder()
+        .scheduleId(schedule.getId())
+        .title(schedule.getTitle())
+        .date(schedule.getDate())
+        .time(schedule.getTime())
+        .type(schedule.getType())
+        .creator(nickName)
+        .attendedNicknames(attendedNicknames)
         .build();
   }
-
 }

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeMonthDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeMonthDto.java
@@ -1,0 +1,33 @@
+package com.campfiredev.growtogether.study.dto.schedule;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleAttendeeMonthDto {
+  private List<ScheduleAttendeeGroup> schedules;
+
+  public static ScheduleAttendeeMonthDto from(
+      Map<LocalDate, List<ScheduleAttendeeDto>> groupedSchedules) {
+    List<ScheduleAttendeeGroup> scheduleGroups = groupedSchedules.entrySet().stream()
+        .map(entry -> new ScheduleAttendeeGroup(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+    return new ScheduleAttendeeMonthDto(scheduleGroups);
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ScheduleAttendeeGroup {
+    private LocalDate date;
+    private List<ScheduleAttendeeDto> schedule;
+  }
+}
+

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleMonthDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleMonthDto.java
@@ -26,6 +26,6 @@ public class ScheduleMonthDto {
   @AllArgsConstructor
   public static class ScheduleGroup {
     private LocalDate date;
-    private List<ScheduleDto> events;
+    private List<ScheduleDto> schedule;
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/entity/attendance/AttendanceEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/entity/attendance/AttendanceEntity.java
@@ -1,0 +1,54 @@
+package com.campfiredev.growtogether.study.entity.attendance;
+
+import com.campfiredev.growtogether.common.entity.BaseEntity;
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
+import com.fasterxml.jackson.annotation.JacksonInject;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "attendance",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "unique_study_member_schedule", columnNames = {"study_member_id",
+            "schedule_id"})
+    })
+public class AttendanceEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "attendance_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "study_member_id", nullable = false)
+  private StudyMemberEntity studyMember;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "schedule_id", nullable = false)
+  private ScheduleEntity schedule;
+
+  public static AttendanceEntity create(StudyMemberEntity studyMember, ScheduleEntity schedule) {
+    return AttendanceEntity
+        .builder()
+        .studyMember(studyMember)
+        .schedule(schedule)
+        .build();
+  }
+}

--- a/src/main/java/com/campfiredev/growtogether/study/entity/schedule/ScheduleEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/entity/schedule/ScheduleEntity.java
@@ -3,6 +3,7 @@ package com.campfiredev.growtogether.study.entity.schedule;
 import static com.campfiredev.growtogether.study.type.ScheduleType.*;
 
 import com.campfiredev.growtogether.study.entity.Study;
+import com.campfiredev.growtogether.study.entity.attendance.AttendanceEntity;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
 import com.campfiredev.growtogether.study.type.ScheduleType;
 import jakarta.persistence.Column;
@@ -15,14 +16,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
@@ -59,6 +63,9 @@ public class ScheduleEntity {
 
   @Enumerated(EnumType.STRING)
   private ScheduleType type;
+
+  @OneToMany(mappedBy = "schedule")
+  private List<AttendanceEntity> attendance;
 
   public static ScheduleEntity create(StudyMemberEntity studyMember, String title, LocalDate date,
       LocalTime time) {

--- a/src/main/java/com/campfiredev/growtogether/study/repository/attendance/AttendanceRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/attendance/AttendanceRepository.java
@@ -1,0 +1,24 @@
+package com.campfiredev.growtogether.study.repository.attendance;
+
+import com.campfiredev.growtogether.study.entity.attendance.AttendanceEntity;
+import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AttendanceRepository extends JpaRepository<AttendanceEntity, Long> {
+
+  boolean existsByStudyMemberIdAndScheduleId(Long studyMemberId, Long scheduleId);
+
+  List<AttendanceEntity> findByScheduleIn(List<ScheduleEntity> scheduleIds);
+
+  @Query("SELECT DISTINCT a FROM AttendanceEntity a "
+      + "LEFT JOIN FETCH a.studyMember sm "
+      + "LEFT JOIN FETCH sm.member attendee "
+      + "WHERE a.schedule IN :schedules")
+  List<AttendanceEntity> findAttendancesBySchedules(
+      @Param("schedules") List<ScheduleEntity> schedules);
+
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
@@ -1,8 +1,11 @@
 package com.campfiredev.growtogether.study.repository.schedule;
 
 import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
+import com.campfiredev.growtogether.study.type.ScheduleType;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,8 +20,15 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
       @Param("date") LocalDate date
   );
 
+  List<ScheduleEntity> findByStudyStudyIdAndTypeAndDateBetween(
+      Long studyId, ScheduleType type, LocalDate startDate, LocalDate endDate);
 
-  @Query("SELECT sc FROM ScheduleEntity sc " +
+
+  Optional<ScheduleEntity> findFirstByTypeAndDateAndTimeBetween(ScheduleType type, LocalDate date,
+      LocalTime startTime, LocalTime endTime);
+
+
+  @Query("SELECT DISTINCT sc FROM ScheduleEntity sc " +
       "JOIN FETCH sc.studyMember sm " +
       "JOIN FETCH sm.member m " +
       "WHERE sc.study.studyId = :studyId " +
@@ -28,4 +38,18 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate
   );
+
+  @Query("SELECT DISTINCT s FROM ScheduleEntity s "
+      + "LEFT JOIN FETCH s.studyMember sm "
+      + "LEFT JOIN FETCH sm.member creator "
+      + "LEFT JOIN FETCH s.attendance a "
+      + "LEFT JOIN FETCH a.studyMember asm "
+      + "LEFT JOIN FETCH asm.member attendee "
+      + "WHERE s.study.studyId = :studyId AND s.date BETWEEN :startDate AND :endDate")
+  List<ScheduleEntity> findSchedulesWithAttendee(
+      @Param("studyId") Long studyId,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate);
+
+
 }

--- a/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
@@ -1,0 +1,83 @@
+package com.campfiredev.growtogether.study.service.attendance;
+
+import static com.campfiredev.growtogether.study.type.ScheduleType.*;
+import static com.campfiredev.growtogether.study.type.StudyMemberType.LEADER;
+import static com.campfiredev.growtogether.study.type.StudyMemberType.NORMAL;
+
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
+import com.campfiredev.growtogether.study.dto.attendance.AttendanceDto;
+import com.campfiredev.growtogether.study.entity.attendance.AttendanceEntity;
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
+import com.campfiredev.growtogether.study.repository.attendance.AttendanceRepository;
+import com.campfiredev.growtogether.study.repository.join.JoinRepository;
+import com.campfiredev.growtogether.study.repository.schedule.ScheduleRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AttendanceService {
+
+  private final AttendanceRepository attendanceRepository;
+  private final ScheduleRepository scheduleRepository;
+  private final JoinRepository joinRepository;
+
+  public void attendance(Long memberId, Long studyId) {
+
+    StudyMemberEntity studyMemberEntity = joinRepository.findByMemberIdAndStudyIdInStatus(memberId,
+            studyId, List.of(NORMAL, LEADER))
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_A_STUDY_MEMBER));
+
+    ScheduleEntity scheduleEntity = scheduleRepository.findFirstByTypeAndDateAndTimeBetween(MAIN,
+            LocalDate.now(),
+            LocalTime.now().minusMinutes(10), LocalTime.now().plusMinutes(10))
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_ATTENDANCE_TIME));
+
+    if (attendanceRepository.existsByStudyMemberIdAndScheduleId(studyMemberEntity.getId(),
+        scheduleEntity.getId())) {
+      throw new CustomException(ErrorCode.ALREADY_ATTENDANCE);
+    }
+
+    attendanceRepository.save(AttendanceEntity.create(studyMemberEntity, scheduleEntity));
+  }
+
+  public List<AttendanceDto> getAttendee(Long studyId, String date) {
+    YearMonth yearMonth = YearMonth.parse(date);
+
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+
+    List<ScheduleEntity> schedules = scheduleRepository.findByStudyStudyIdAndTypeAndDateBetween(
+        studyId, MAIN, startDate, endDate);
+
+    List<AttendanceEntity> attendee = attendanceRepository.findAttendancesBySchedules(
+        schedules);
+
+    Map<Long, AttendanceDto> scheduleAttendanceMap = schedules.stream()
+        .collect(Collectors.toMap(
+            scheduleEntity -> scheduleEntity.getId(),
+            schedule -> new AttendanceDto(schedule.getId(), schedule.getDate(), schedule.getTime(),
+                new ArrayList<>())
+        ));
+
+    attendee.forEach(attendance ->
+        scheduleAttendanceMap.get(attendance.getSchedule().getId())
+            .getAttendees().add(attendance.getStudyMember().getMember().getNickName())
+    );
+
+    return new ArrayList<>(scheduleAttendanceMap.values());
+  }
+
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
@@ -6,8 +6,11 @@ import static com.campfiredev.growtogether.study.type.StudyMemberType.LEADER;
 import static com.campfiredev.growtogether.study.type.StudyMemberType.NORMAL;
 
 import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleAttendeeDto;
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleAttendeeMonthDto;
 import com.campfiredev.growtogether.study.entity.Study;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import com.campfiredev.growtogether.study.repository.attendance.AttendanceRepository;
 import com.campfiredev.growtogether.study.repository.join.JoinRepository;
 import com.campfiredev.growtogether.study.dto.schedule.MainScheduleDto;
 import com.campfiredev.growtogether.study.dto.schedule.ScheduleCreateDto;
@@ -21,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +41,7 @@ public class ScheduleService {
   private final ScheduleRepository scheduleRepository;
   private final JoinRepository joinRepository;
   private final VoteService voteService;
+  private final AttendanceRepository attendanceRepository;
 
   public void createMainSchedule(Study study, Long memberId, List<MainScheduleDto> mainList) {
     mainList.sort(Comparator.comparing(s -> s.getStartTime()));
@@ -120,6 +125,33 @@ public class ScheduleService {
         .collect(Collectors.groupingBy(scheduleDto -> scheduleDto.getDate()));
 
     return ScheduleMonthDto.from(collect);
+  }
+
+  public ScheduleAttendeeMonthDto getMonthSchedulesAttendees(Long studyId, String date) {
+    YearMonth yearMonth = YearMonth.parse(date);
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+
+    List<ScheduleEntity> schedules = scheduleRepository.findSchedulesWithAttendee(studyId, startDate, endDate);
+
+    Map<Long, List<String>> attendanceMap = schedules.stream()
+        .flatMap(schedule -> schedule.getAttendance().stream()
+            .map(attendance -> Map.entry(schedule.getId(), attendance.getStudyMember().getMember().getNickName()))
+        )
+        .collect(Collectors.groupingBy(
+            Map.Entry::getKey,
+            Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+        ));
+
+    Map<LocalDate, List<ScheduleAttendeeDto>> groupedSchedules = schedules.stream()
+        .map(schedule -> ScheduleAttendeeDto.create(
+            schedule,
+            schedule.getStudyMember().getMember().getNickName(),
+            attendanceMap.getOrDefault(schedule.getId(), new ArrayList<>())
+        ))
+        .collect(Collectors.groupingBy(ScheduleAttendeeDto::getDate));
+
+    return ScheduleAttendeeMonthDto.from(groupedSchedules);
   }
 
   private boolean validateCreateVote(Long memberId, Long scheduleId, ScheduleUpdateDto scheduleUpdateDto,


### PR DESCRIPTION

## 📝 요약(Summary)

- 출석 체크 추가
  메인 일정 시작 시간 +-10 사이에 출석 버튼 누르면 출석 되도록 구현했습니다.
  중복 출석 못하게 구현했습니다.

- 해당 달의 출석자 리스트 조회
   yyyy-dd 형식으로 입력 받아 해당 달의 출석자를 일정 별로 조회합니다.

- 해당 달의 일정 + 해당 일정의 출석자 같이 조회
   yyyy-dd 형식으로 입력 받아 해당 달의 모든 일정을 조회하고 일정마다 참석자 리스트를 같이 리턴합니다.


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
해당 달의 출석자 리스트 조회
![image](https://github.com/user-attachments/assets/00470700-bee1-433b-b1b3-d3c7d13a9af1)

해당 달의 일정 + 해당 일정의 출석자 같이 조회
![image](https://github.com/user-attachments/assets/3fde0aa6-9626-43b4-bb56-ef0efe0f668d)


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->