### PR TITLE
refactor: ScheduleEntity 필드 변경, 일정 변경 시 겹치는 일정 확인하도록 변경

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/study/dto/attendance/AttendanceDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/attendance/AttendanceDto.java
@@ -1,7 +1,6 @@
 package com.campfiredev.growtogether.study.dto.attendance;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AttendanceDto {
   private Long scheduleId;
-  private LocalDate date;
-  private LocalTime time;
+  private LocalDateTime date;
   private List<String> attendees;
 }

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/MainScheduleDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/MainScheduleDto.java
@@ -8,10 +8,12 @@ import lombok.Getter;
 public class MainScheduleDto {
   LocalDateTime startTime;
   LocalDateTime endTime;
+  Integer total;
 
   public MainScheduleDto(String date, String time, int total) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     this.startTime = LocalDateTime.parse(date + " " + time, formatter);
     this.endTime = this.startTime.plusMinutes(total);
+    this.total = total;
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleAttendeeDto.java
@@ -3,6 +3,7 @@ package com.campfiredev.growtogether.study.dto.schedule;
 import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
 import com.campfiredev.growtogether.study.type.ScheduleType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -18,8 +19,9 @@ public class ScheduleAttendeeDto {
 
   private Long scheduleId;
   private String title;
-  private LocalDate date;
-  private LocalTime time;
+  private LocalDateTime start;
+  private LocalDateTime end;
+  private Integer totalTime;
   private ScheduleType type;
   private String creator;
   private List<String> attendedNicknames;
@@ -28,8 +30,9 @@ public class ScheduleAttendeeDto {
     return ScheduleAttendeeDto.builder()
         .scheduleId(schedule.getId())
         .title(schedule.getTitle())
-        .date(schedule.getDate())
-        .time(schedule.getTime())
+        .start(schedule.getStart())
+        .end(schedule.getEnd())
+        .totalTime(schedule.getTotalTime())
         .type(schedule.getType())
         .creator(nickName)
         .attendedNicknames(attendedNicknames)

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleCreateDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleCreateDto.java
@@ -19,8 +19,11 @@ public class ScheduleCreateDto {
   private String title;
 
   @NotNull
-  private LocalDate date;
+  private LocalDate startDate;
 
   @NotNull
-  private LocalTime time;
+  private LocalTime startTime;
+
+  @NotNull
+  private Integer totalTime;
 }

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleDto.java
@@ -3,6 +3,7 @@ package com.campfiredev.growtogether.study.dto.schedule;
 import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
 import com.campfiredev.growtogether.study.type.ScheduleType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,9 +20,11 @@ public class ScheduleDto {
 
   private String title;
 
-  private LocalDate date;
+  private LocalDateTime start;
 
-  private LocalTime time;
+  private LocalDateTime end;
+
+  private Integer totalTime;
 
   private ScheduleType scheduleType;
 
@@ -31,8 +34,9 @@ public class ScheduleDto {
     return ScheduleDto.builder()
         .scheduleId(scheduleEntity.getId())
         .title(scheduleEntity.getTitle())
-        .date(scheduleEntity.getDate())
-        .time(scheduleEntity.getTime())
+        .start(scheduleEntity.getStart())
+        .end(scheduleEntity.getEnd())
+        .totalTime(scheduleEntity.getTotalTime())
         .scheduleType(scheduleEntity.getType())
         .creator(scheduleEntity.getStudyMember().getMember().getNickName())
         .build();

--- a/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleUpdateDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/schedule/ScheduleUpdateDto.java
@@ -19,9 +19,12 @@ public class ScheduleUpdateDto {
   private String title;
 
   @NotNull
-  private LocalDate date;
+  private LocalDate startDate;
 
   @NotNull
-  private LocalTime time;
+  private LocalTime startTime;
+
+  @NotNull
+  private Integer totalTime;
 
 }

--- a/src/main/java/com/campfiredev/growtogether/study/entity/schedule/ScheduleEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/entity/schedule/ScheduleEntity.java
@@ -2,6 +2,7 @@ package com.campfiredev.growtogether.study.entity.schedule;
 
 import static com.campfiredev.growtogether.study.type.ScheduleType.*;
 
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleCreateDto;
 import com.campfiredev.growtogether.study.entity.Study;
 import com.campfiredev.growtogether.study.entity.attendance.AttendanceEntity;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
@@ -18,15 +19,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
@@ -47,11 +46,15 @@ public class ScheduleEntity {
 
   @Column(nullable = false)
   @Setter
-  private LocalDate date;
+  private LocalDateTime start;
 
   @Column(nullable = false)
   @Setter
-  private LocalTime time;
+  private LocalDateTime end;
+
+  @Column(nullable = false)
+  @Setter
+  private Integer totalTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "study_member_id", nullable = false)
@@ -67,14 +70,18 @@ public class ScheduleEntity {
   @OneToMany(mappedBy = "schedule")
   private List<AttendanceEntity> attendance;
 
-  public static ScheduleEntity create(StudyMemberEntity studyMember, String title, LocalDate date,
-      LocalTime time) {
+  public static ScheduleEntity create(StudyMemberEntity studyMember, ScheduleCreateDto scheduleCreateDto) {
+
+    LocalDateTime start = LocalDateTime.of(scheduleCreateDto.getStartDate(), scheduleCreateDto.getStartTime());
+    LocalDateTime end = start.plusMinutes(scheduleCreateDto.getTotalTime());
+
     return ScheduleEntity.builder()
-        .title(title)
-        .date(date)
-        .time(time)
+        .title(scheduleCreateDto.getTitle())
+        .start(start)
+        .end(end)
         .studyMember(studyMember)
         .study(studyMember.getStudy())
+        .totalTime(scheduleCreateDto.getTotalTime())
         .type(OTHER)
         .build();
   }

--- a/src/main/java/com/campfiredev/growtogether/study/entity/vote/ChangeVoteEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/study/entity/vote/ChangeVoteEntity.java
@@ -2,11 +2,11 @@ package com.campfiredev.growtogether.study.entity.vote;
 
 import static com.campfiredev.growtogether.study.type.VoteStatus.PROGRESS;
 
+import com.campfiredev.growtogether.study.dto.schedule.ScheduleUpdateDto;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -24,21 +24,28 @@ public class ChangeVoteEntity extends VoteEntity {
 
   private String content;
 
-  private LocalDate date;
+  private LocalDateTime start;
 
-  private LocalTime time;
+  private LocalDateTime end;
+
+  private Integer total;
 
   public static ChangeVoteEntity create(String title, StudyMemberEntity studyMemberEntity,
-      String content, LocalDate date, LocalTime time, Long scheduleId) {
+     ScheduleUpdateDto scheduleUpdateDto, Long scheduleId) {
+
+    LocalDateTime start = LocalDateTime.of(scheduleUpdateDto.getStartDate(),
+        scheduleUpdateDto.getStartTime());
+
     return ChangeVoteEntity.builder()
         .title(title)
         .scheduleId(scheduleId)
         .studyMember(studyMemberEntity)
         .study(studyMemberEntity.getStudy())
         .status(PROGRESS)
-        .content(content)
-        .date(date)
-        .time(time)
+        .content(scheduleUpdateDto.getTitle())
+        .start(start)
+        .end(start.plusMinutes(scheduleUpdateDto.getTotalTime()))
+        .total(scheduleUpdateDto.getTotalTime())
         .build();
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/repository/attendance/AttendanceRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/attendance/AttendanceRepository.java
@@ -2,6 +2,7 @@ package com.campfiredev.growtogether.study.repository.attendance;
 
 import com.campfiredev.growtogether.study.entity.attendance.AttendanceEntity;
 import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,6 +20,14 @@ public interface AttendanceRepository extends JpaRepository<AttendanceEntity, Lo
       + "WHERE a.schedule IN :schedules")
   List<AttendanceEntity> findAttendancesBySchedules(
       @Param("schedules") List<ScheduleEntity> schedules);
+
+  @Query("SELECT a FROM AttendanceEntity a "
+      + "JOIN FETCH a.studyMember sm "
+      + "JOIN FETCH sm.member m "
+      + "JOIN FETCH a.schedule s "
+      + "WHERE sm.study.studyId = :studyId AND s.start BETWEEN :start AND :end")
+  List<AttendanceEntity> findAttendancesBetween(@Param("studyId") Long studyId, @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 
 
 }

--- a/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
@@ -1,8 +1,11 @@
 package com.campfiredev.growtogether.study.repository.schedule;
 
+import com.campfiredev.growtogether.study.entity.Study;
 import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
 import com.campfiredev.growtogether.study.type.ScheduleType;
+import jakarta.ejb.Schedule;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -14,29 +17,28 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
 
   @Query("SELECT sc FROM ScheduleEntity sc JOIN FETCH sc.studyMember sm "
       + "JOIN FETCH sm.member m "
-      + "WHERE sc.study.studyId = :studyId AND sc.date = :date")
+      + "WHERE sc.study.studyId = :studyId "
+      + "AND sc.start BETWEEN :startOfDay AND :endOfDay")
   List<ScheduleEntity> findWithMemberByStudyIdAndDate(
       @Param("studyId") Long studyId,
-      @Param("date") LocalDate date
+      @Param("startOfDay") LocalDateTime startOfDay,
+      @Param("endOfDay") LocalDateTime endOfDay
   );
 
-  List<ScheduleEntity> findByStudyStudyIdAndTypeAndDateBetween(
-      Long studyId, ScheduleType type, LocalDate startDate, LocalDate endDate);
 
-
-  Optional<ScheduleEntity> findFirstByTypeAndDateAndTimeBetween(ScheduleType type, LocalDate date,
-      LocalTime startTime, LocalTime endTime);
+  Optional<ScheduleEntity> findFirstByTypeAndStartBetween(ScheduleType type,
+      LocalDateTime start, LocalDateTime end);
 
 
   @Query("SELECT DISTINCT sc FROM ScheduleEntity sc " +
       "JOIN FETCH sc.studyMember sm " +
       "JOIN FETCH sm.member m " +
       "WHERE sc.study.studyId = :studyId " +
-      "AND sc.date BETWEEN :startDate AND :endDate")
+      "AND sc.start BETWEEN :startDate AND :endDate")
   List<ScheduleEntity> findWithMemberByStudyIdAndDateBetween(
       @Param("studyId") Long studyId,
-      @Param("startDate") LocalDate startDate,
-      @Param("endDate") LocalDate endDate
+      @Param("startDate") LocalDateTime start,
+      @Param("endDate") LocalDateTime end
   );
 
   @Query("SELECT DISTINCT s FROM ScheduleEntity s "
@@ -45,11 +47,14 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
       + "LEFT JOIN FETCH s.attendance a "
       + "LEFT JOIN FETCH a.studyMember asm "
       + "LEFT JOIN FETCH asm.member attendee "
-      + "WHERE s.study.studyId = :studyId AND s.date BETWEEN :startDate AND :endDate")
+      + "WHERE s.study.studyId = :studyId AND s.start BETWEEN :start AND :end")
   List<ScheduleEntity> findSchedulesWithAttendee(
       @Param("studyId") Long studyId,
-      @Param("startDate") LocalDate startDate,
-      @Param("endDate") LocalDate endDate);
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  List<ScheduleEntity> findByStudyAndStartBetweenAndType(Study study, LocalDateTime start,
+      LocalDateTime end, ScheduleType type);
 
 
 }

--- a/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
@@ -14,6 +14,7 @@ import com.campfiredev.growtogether.study.repository.attendance.AttendanceReposi
 import com.campfiredev.growtogether.study.repository.join.JoinRepository;
 import com.campfiredev.growtogether.study.repository.schedule.ScheduleRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -39,9 +40,10 @@ public class AttendanceService {
             studyId, List.of(NORMAL, LEADER))
         .orElseThrow(() -> new CustomException(ErrorCode.NOT_A_STUDY_MEMBER));
 
-    ScheduleEntity scheduleEntity = scheduleRepository.findFirstByTypeAndDateAndTimeBetween(MAIN,
-            LocalDate.now(),
-            LocalTime.now().minusMinutes(10), LocalTime.now().plusMinutes(10))
+    LocalDateTime now = LocalDateTime.now();
+
+    ScheduleEntity scheduleEntity = scheduleRepository.findFirstByTypeAndStartBetween(
+            MAIN, now.minusMinutes(10), now.plusMinutes(10))
         .orElseThrow(() -> new CustomException(ErrorCode.INVALID_ATTENDANCE_TIME));
 
     if (attendanceRepository.existsByStudyMemberIdAndScheduleId(studyMemberEntity.getId(),
@@ -58,25 +60,27 @@ public class AttendanceService {
     LocalDate startDate = yearMonth.atDay(1);
     LocalDate endDate = yearMonth.atEndOfMonth();
 
-    List<ScheduleEntity> schedules = scheduleRepository.findByStudyStudyIdAndTypeAndDateBetween(
-        studyId, MAIN, startDate, endDate);
+    List<AttendanceEntity> attendees = attendanceRepository.findAttendancesBetween(
+        studyId, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
 
-    List<AttendanceEntity> attendee = attendanceRepository.findAttendancesBySchedules(
-        schedules);
+    Map<Long, List<String>> collect = attendees.stream()
+        .collect(
+            Collectors.groupingBy(attendee -> attendee.getSchedule().getId(),
+                Collectors.mapping(attendee -> attendee.getStudyMember().getMember().getNickName(),
+                    Collectors.toList())));
 
-    Map<Long, AttendanceDto> scheduleAttendanceMap = schedules.stream()
-        .collect(Collectors.toMap(
-            scheduleEntity -> scheduleEntity.getId(),
-            schedule -> new AttendanceDto(schedule.getId(), schedule.getDate(), schedule.getTime(),
-                new ArrayList<>())
-        ));
+    return collect.entrySet().stream()
+        .map(entry -> {
+          ScheduleEntity scheduleEntity = attendees.stream()
+              .filter(attendee -> attendee.getSchedule().getId().equals(entry.getKey()))
+              .findFirst().map(attendee -> attendee.getSchedule()).orElseThrow();
 
-    attendee.forEach(attendance ->
-        scheduleAttendanceMap.get(attendance.getSchedule().getId())
-            .getAttendees().add(attendance.getStudyMember().getMember().getNickName())
-    );
-
-    return new ArrayList<>(scheduleAttendanceMap.values());
+          return AttendanceDto.builder()
+              .scheduleId(scheduleEntity.getId())
+              .date(scheduleEntity.getStart())
+              .attendees(entry.getValue())
+              .build();
+        }).collect(Collectors.toList());
   }
 
 

--- a/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
@@ -21,9 +21,9 @@ import com.campfiredev.growtogether.study.entity.schedule.ScheduleEntity;
 import com.campfiredev.growtogether.study.repository.schedule.ScheduleRepository;
 import com.campfiredev.growtogether.study.service.vote.VoteService;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -50,23 +50,21 @@ public class ScheduleService {
       MainScheduleDto prev = mainList.get(i - 1);
       MainScheduleDto current = mainList.get(i);
 
-      if (!current.getStartTime().isAfter(prev.getStartTime())) {
+      if (!current.getStartTime().isAfter(prev.getEndTime())) {
         throw new CustomException(ALREADY_EXISTS_SCHEDULE);
       }
     }
 
     StudyMemberEntity studyMemberEntity = getStudyMemberEntity(study.getStudyId(), memberId);
 
-    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
-
     List<ScheduleEntity> schedules = mainList.stream()
         .map(main -> ScheduleEntity.builder()
             .title("메인 일정입니다.")
             .studyMember(studyMemberEntity)
             .study(study)
-            .date(LocalDate.parse(main.getStartTime().format(dateFormatter)))
-            .time(LocalTime.parse(main.getStartTime().format(timeFormatter)))
+            .start(main.getStartTime())
+            .end(main.getEndTime())
+            .totalTime(main.getTotal())
             .type(MAIN)
             .build())
         .collect(Collectors.toList());
@@ -77,27 +75,45 @@ public class ScheduleService {
   public void createSchedule(Long studyId, Long memberId, ScheduleCreateDto scheduleCreateDto) {
     StudyMemberEntity studyMemberEntity = getStudyMemberEntity(studyId, memberId);
 
-    scheduleRepository.save(ScheduleEntity.create(studyMemberEntity, scheduleCreateDto.getTitle(),
-        scheduleCreateDto.getDate(), scheduleCreateDto.getTime()));
+    scheduleRepository.save(ScheduleEntity.create(studyMemberEntity, scheduleCreateDto));
   }
 
-  public void updateSchedule(Long memberId, Long scheduleId, ScheduleUpdateDto scheduleUpdateDto) {
+  public void updateSchedule(Long memberId, Long scheduleId, ScheduleUpdateDto updateDto) {
     ScheduleEntity scheduleEntity = getScheduleEntity(scheduleId);
 
-    if(validateCreateVote(memberId, scheduleId, scheduleUpdateDto, scheduleEntity)) return;
+    LocalDateTime start = LocalDateTime.of(updateDto.getStartDate(), updateDto.getStartTime());
+    LocalDateTime end = start.plusMinutes(updateDto.getTotalTime());
+
+    List<ScheduleEntity> mainSchedules = scheduleRepository.findByStudyAndStartBetweenAndType(
+        scheduleEntity.getStudy(), start, end, MAIN);
+
+    for (ScheduleEntity schedule : mainSchedules) {
+      if (schedule.getId().equals(scheduleId)) {
+        continue;
+      }
+
+      if (start.isAfter(schedule.getStart()) && start.isBefore(schedule.getEnd())) {
+        throw new CustomException(ALREADY_EXISTS_SCHEDULE);
+      }
+    }
+
+    if (validateCreateVote(memberId, scheduleId, updateDto, scheduleEntity, start, end)) {
+      return;
+    }
 
     validateSameUser(memberId, scheduleEntity);
 
-    scheduleEntity.setTitle(scheduleUpdateDto.getTitle());
-    scheduleEntity.setDate(scheduleUpdateDto.getDate());
-    scheduleEntity.setTime(scheduleUpdateDto.getTime());
+    scheduleEntity.setTitle(updateDto.getTitle());
+    scheduleEntity.setStart(start);
+    scheduleEntity.setEnd(end);
+    scheduleEntity.setTotalTime(updateDto.getTotalTime());
   }
 
 
   public void deleteSchedule(Long memberId, Long scheduleId) {
     ScheduleEntity scheduleEntity = getScheduleEntity(scheduleId);
 
-    if(MAIN.equals(scheduleEntity.getType())){
+    if (MAIN.equals(scheduleEntity.getType())) {
       throw new CustomException(CANNOT_DELETE_MAIN_SCHEDULE);
     }
 
@@ -107,7 +123,8 @@ public class ScheduleService {
   }
 
   public List<ScheduleDto> getSchedules(Long studyId, LocalDate date) {
-    return scheduleRepository.findWithMemberByStudyIdAndDate(studyId, date).stream()
+    return scheduleRepository.findWithMemberByStudyIdAndDate(studyId, date.atStartOfDay(),
+            date.atTime(LocalTime.MAX)).stream()
         .map(entity -> ScheduleDto.fromEntity(entity))
         .collect(Collectors.toList());
   }
@@ -119,10 +136,10 @@ public class ScheduleService {
     LocalDate endDate = yearMonth.atEndOfMonth();
 
     Map<LocalDate, List<ScheduleDto>> collect = scheduleRepository.findWithMemberByStudyIdAndDateBetween(
-            studyId, startDate, endDate)
+            studyId, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
         .stream()
         .map(scheduleEntity -> ScheduleDto.fromEntity(scheduleEntity))
-        .collect(Collectors.groupingBy(scheduleDto -> scheduleDto.getDate()));
+        .collect(Collectors.groupingBy(scheduleDto -> scheduleDto.getStart().toLocalDate()));
 
     return ScheduleMonthDto.from(collect);
   }
@@ -132,15 +149,17 @@ public class ScheduleService {
     LocalDate startDate = yearMonth.atDay(1);
     LocalDate endDate = yearMonth.atEndOfMonth();
 
-    List<ScheduleEntity> schedules = scheduleRepository.findSchedulesWithAttendee(studyId, startDate, endDate);
+    List<ScheduleEntity> schedules = scheduleRepository.findSchedulesWithAttendee(studyId,
+        startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
 
     Map<Long, List<String>> attendanceMap = schedules.stream()
         .flatMap(schedule -> schedule.getAttendance().stream()
-            .map(attendance -> Map.entry(schedule.getId(), attendance.getStudyMember().getMember().getNickName()))
+            .map(attendance -> Map.entry(schedule.getId(),
+                attendance.getStudyMember().getMember().getNickName()))
         )
         .collect(Collectors.groupingBy(
-            Map.Entry::getKey,
-            Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+            id -> id.getKey(),
+            Collectors.mapping(attend -> attend.getValue(), Collectors.toList())
         ));
 
     Map<LocalDate, List<ScheduleAttendeeDto>> groupedSchedules = schedules.stream()
@@ -149,16 +168,18 @@ public class ScheduleService {
             schedule.getStudyMember().getMember().getNickName(),
             attendanceMap.getOrDefault(schedule.getId(), new ArrayList<>())
         ))
-        .collect(Collectors.groupingBy(ScheduleAttendeeDto::getDate));
+        .collect(Collectors.groupingBy(
+            (ScheduleAttendeeDto scheduleAttendeeDto) -> scheduleAttendeeDto.getStart().toLocalDate()));
 
     return ScheduleAttendeeMonthDto.from(groupedSchedules);
   }
 
-  private boolean validateCreateVote(Long memberId, Long scheduleId, ScheduleUpdateDto scheduleUpdateDto,
-      ScheduleEntity scheduleEntity) {
-    if (MAIN.equals(scheduleEntity.getType()) && (
-        !scheduleEntity.getDate().equals(scheduleUpdateDto.getDate()) || !scheduleEntity.getTime()
-            .equals(scheduleUpdateDto.getTime()))) {
+  private boolean validateCreateVote(Long memberId, Long scheduleId,
+      ScheduleUpdateDto scheduleUpdateDto,
+      ScheduleEntity scheduleEntity, LocalDateTime start, LocalDateTime end) {
+
+    if (MAIN.equals(scheduleEntity.getType()) && (!start.equals(scheduleEntity.getStart()))
+        || !end.equals(scheduleEntity.getEnd())) {
       voteService.createChangeVote(memberId, scheduleEntity.getStudy().getStudyId(), scheduleId,
           scheduleUpdateDto);
       return true;
@@ -170,7 +191,7 @@ public class ScheduleService {
     StudyMemberEntity studyMemberEntity = getStudyMemberEntity(memberId,
         scheduleEntity.getStudy().getStudyId());
 
-    if(!memberId.equals(studyMemberEntity.getId())) {
+    if (!memberId.equals(studyMemberEntity.getId())) {
       throw new CustomException(NOT_AUTHOR);
     }
   }

--- a/src/main/java/com/campfiredev/growtogether/study/service/vote/ChangeVoteProcessor.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/vote/ChangeVoteProcessor.java
@@ -25,17 +25,17 @@ public class ChangeVoteProcessor implements VoteProcessor {
   public void processVote(VoteEntity voteEntity, int votes, int totalSize) {
     if (votes >= totalSize) {
       ChangeVoteEntity changeVoteEntity = (ChangeVoteEntity) voteEntity;
-      log.info("CHANGE 투표 통과: " + changeVoteEntity.getDate());
-      log.info("시간 변경: " + changeVoteEntity.getTime());
+      log.info("CHANGE 투표 통과: " + changeVoteEntity.getStart());
+      log.info("시간 변경: " + changeVoteEntity.getEnd());
 
       ScheduleEntity scheduleEntity = scheduleRepository.findById(changeVoteEntity.getScheduleId())
           .orElseThrow(() -> new CustomException(ErrorCode.SCHEDULE_NOT_FOUND));
 
       scheduleEntity.setTitle(changeVoteEntity.getContent());
-      scheduleEntity.setDate(changeVoteEntity.getDate());
-      scheduleEntity.setTime(changeVoteEntity.getTime());
-
-      redisTemplate.delete("vote" + voteEntity.getId());
+      scheduleEntity.setStart(changeVoteEntity.getStart());
+      scheduleEntity.setEnd(changeVoteEntity.getEnd());
+      scheduleEntity.setTotalTime(changeVoteEntity.getTotal());
     }
+    redisTemplate.delete("vote" + voteEntity.getId());
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/service/vote/KickVoteProcessor.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/vote/KickVoteProcessor.java
@@ -32,8 +32,7 @@ public class KickVoteProcessor implements VoteProcessor {
 
       studyMemberEntity.setStatus(KICK);
       log.info("KICK 투표 통과: " + studyMemberEntity.getId() + " 강퇴됨");
-
-      redisTemplate.delete("vote" + voteEntity.getId());
     }
+    redisTemplate.delete("vote" + voteEntity.getId());
   }
 }

--- a/src/main/java/com/campfiredev/growtogether/study/service/vote/VoteService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/vote/VoteService.java
@@ -22,6 +22,7 @@ import com.campfiredev.growtogether.study.repository.vote.ChangeVoteRepository;
 import com.campfiredev.growtogether.study.repository.vote.KickVoteRepository;
 import com.campfiredev.growtogether.study.repository.vote.VoteRepository;
 import com.campfiredev.growtogether.study.repository.vote.VotingRepository;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,8 +69,7 @@ public class VoteService {
     String title = scheduleId + "번 스케줄 시간 변경 투표입니다.";
 
     ChangeVoteEntity save = changeVoteRepository.save(
-        ChangeVoteEntity.create(title, studyMemberEntity, scheduleUpdateDto.getTitle(),
-            scheduleUpdateDto.getDate(), scheduleUpdateDto.getTime(), scheduleId));
+        ChangeVoteEntity.create(title, studyMemberEntity, scheduleUpdateDto, scheduleId));
 
     scheduleJob(ChangeVoteJob.class, "changeJob", "changeGroup", 3, save.getId());
   }


### PR DESCRIPTION
ScheduleEntity에서 
date, time 필드 삭제

LocalDateTime start(일정 시작 시각) 필드 추가
LocalDateTime end(일정 종료 시각) 필드 추가
Integer total(일정 진행 예정 시간) 필드 추가

MainScheduleDto total(총 진행 예정시간) 필드 추가
AttendanceDto LocalDate date, LocalTime time -> LocalDateTime date로 변경
일정 변경 투표 생성 시 start, end, total 필드 저장하도록 변경, 투표 가결 시 start, end, total update 되도록 변경
해당 달의 모든 일정의 출석자 리스트 조회 시 기존 쿼리 2번 -> 쿼리 1번으로 변경
일정 변경 시 변경하려는 시간이 메인 일정과 겹치는지 확인하는 로직 추가

그 외 모든 Schedule 관련 dto들 LocalDate date, LocalTime time 삭제 후 LocalDateTime start, LocalDateTime end 추가
그에 맞게 쿼리, 서비스 로직 수정


## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
추후 코드 깔끔하게 리팩토링해서 pr 올리겠습니다.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->