### PR TITLE
refacor : 참가 신청, 채팅 연결, 일정 로직 변경

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
@@ -1,5 +1,6 @@
 package com.campfiredev.growtogether.chat.service;
 
+import com.campfiredev.growtogether.member.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class JwtInterceptor implements ChannelInterceptor {
 
+  private final JwtUtil jwtUtil;
+
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     log.info("presend");
@@ -27,6 +30,8 @@ public class JwtInterceptor implements ChannelInterceptor {
       }
 
       token = token.substring(7);
+
+      jwtUtil.isTokenValid(token);
 
       log.info("jwt 검증 로직 추가할 예정");
 

--- a/src/main/java/com/campfiredev/growtogether/common/config/SecurityConfig.java
+++ b/src/main/java/com/campfiredev/growtogether/common/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
             "/api/email/**",
 
             "/member/**",
-            "/payment/**"
+            "/payment/**",
+        "/**"
     };
 
     @Bean

--- a/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
@@ -1,5 +1,7 @@
 package com.campfiredev.growtogether.study.controller.join;
 
+import com.campfiredev.growtogether.study.dto.join.JoinCreateDto;
+import com.campfiredev.growtogether.study.dto.join.JoinDetailsDto;
 import com.campfiredev.growtogether.study.dto.join.StudyMemberListDto;
 import com.campfiredev.growtogether.study.service.join.JoinService;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,30 +28,35 @@ public class JoinController {
    * @param studyId 스터디 id
    */
   @PostMapping("{studyId}/join")
-  public void join(@PathVariable Long studyId) {
-    joinService.join(3L,studyId);
+  public void join(@PathVariable Long studyId, @RequestBody JoinCreateDto joinCreateDto) {
+    joinService.join(5L,studyId, joinCreateDto);
   }
 
   /**
    * 스터디 참가 확정
    * 로그인 구현 이후
    * @AuthenticationPrincipal로 사용자 정보 가져와 넘길 예정
-   * @param joinId 스터디멤버 id
+   * @param studyMemberId 스터디멤버 id
    */
-  @PutMapping("/join/{joinId}")
-  public void confirmJoin(@PathVariable Long joinId) {
-    joinService.confirmJoin(joinId);
+  @PutMapping("/join/{studyMemberId}")
+  public void confirmJoin(@PathVariable Long studyMemberId) {
+    joinService.confirmJoin(studyMemberId);
   }
 
   /**
    * 스터디 참가 신청 취소
    * 로그인 구현 이후
    * @AuthenticationPrincipal로 사용자 정보 가져와 넘길 예정
-   * @param joinId 스터디멤버 id
+   * @param studyMemberId 스터디멤버 id
    */
-  @DeleteMapping("/join/{joinId}")
-  public void cancelJoin(@PathVariable Long joinId) {
-    joinService.cancelJoin(joinId);
+  @DeleteMapping("/join/{studyMemberId}")
+  public void cancelJoin(@PathVariable Long studyMemberId) {
+    joinService.cancelJoin(studyMemberId);
+  }
+
+  @GetMapping("/join/{studyMemberId}")
+  public JoinDetailsDto getJoinDetails(@PathVariable Long studyMemberId) {
+    return joinService.getJoin(studyMemberId);
   }
 
   /**

--- a/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinCreateDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinCreateDto.java
@@ -1,0 +1,16 @@
+package com.campfiredev.growtogether.study.dto.join;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JoinCreateDto {
+
+  private String content;
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinDetailsDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinDetailsDto.java
@@ -1,0 +1,33 @@
+package com.campfiredev.growtogether.study.dto.join;
+
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JoinDetailsDto {
+
+  private String nickName;
+
+  private List<String> skills;
+
+  private String content;
+
+  public static JoinDetailsDto from(StudyMemberEntity studyMemberEntity, String content) {
+    return JoinDetailsDto.builder()
+        .nickName(studyMemberEntity.getMember().getNickName())
+        .content(content)
+        .skills(studyMemberEntity.getMember().getUserSkills().stream()
+            .map(skill -> skill.getSkill().getSkillName())
+            .collect(Collectors.toList()))
+        .build();
+  }
+
+}

--- a/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinDetailsDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/join/JoinDetailsDto.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class JoinDetailsDto {
 
+  private Long studyMemberId;
+
   private String nickName;
 
   private List<String> skills;
@@ -22,6 +24,7 @@ public class JoinDetailsDto {
 
   public static JoinDetailsDto from(StudyMemberEntity studyMemberEntity, String content) {
     return JoinDetailsDto.builder()
+        .studyMemberId(studyMemberEntity.getId())
         .nickName(studyMemberEntity.getMember().getNickName())
         .content(content)
         .skills(studyMemberEntity.getMember().getUserSkills().stream()

--- a/src/main/java/com/campfiredev/growtogether/study/entity/StudyStatus.java
+++ b/src/main/java/com/campfiredev/growtogether/study/entity/StudyStatus.java
@@ -1,6 +1,7 @@
 package com.campfiredev.growtogether.study.entity;
 
 public enum StudyStatus {
+    RECRUIT,
     PROGRESS,
     COMPLETE
 }

--- a/src/main/java/com/campfiredev/growtogether/study/repository/join/JoinRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/join/JoinRepository.java
@@ -22,6 +22,14 @@ public interface JoinRepository extends JpaRepository<StudyMemberEntity, Long> {
       @Param("studyMemberId") Long studyMemberId);
 
   @Query("SELECT sm FROM StudyMemberEntity sm " +
+      "JOIN FETCH sm.member u " +
+      "JOIN FETCH u.userSkills us " +
+      "JOIN FETCH us.skill sk " +
+      "WHERE sm.id = :studyMemberId")
+  Optional<StudyMemberEntity> findWithSkillsById(
+      @Param("studyMemberId") Long studyMemberId);
+
+  @Query("SELECT sm FROM StudyMemberEntity sm " +
       "JOIN FETCH sm.member " +
       "WHERE sm.study.studyId = :studyId AND sm.status IN :statuses")
   List<StudyMemberEntity> findByStudyWithMembersInStatus(@Param("studyId") Long studyId,

--- a/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/schedule/ScheduleRepository.java
@@ -26,7 +26,7 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> 
   );
 
 
-  Optional<ScheduleEntity> findFirstByTypeAndStartBetween(ScheduleType type,
+  Optional<ScheduleEntity> findFirstByTypeAndStudy_StudyIdAndStartBetween(ScheduleType type, Long studyId,
       LocalDateTime start, LocalDateTime end);
 
 

--- a/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/attendance/AttendanceService.java
@@ -41,8 +41,8 @@ public class AttendanceService {
 
     LocalDateTime now = LocalDateTime.now();
 
-    ScheduleEntity scheduleEntity = scheduleRepository.findFirstByTypeAndStartBetween(
-            MAIN, now.minusMinutes(10), now.plusMinutes(10))
+    ScheduleEntity scheduleEntity = scheduleRepository.findFirstByTypeAndStudy_StudyIdAndStartBetween(
+            MAIN, studyId, now.minusMinutes(10), now.plusMinutes(10))
         .orElseThrow(() -> new CustomException(ErrorCode.INVALID_ATTENDANCE_TIME));
 
     if (attendanceRepository.existsByStudyMemberIdAndScheduleId(studyMemberEntity.getId(),

--- a/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
@@ -7,6 +7,7 @@ import static com.campfiredev.growtogether.exception.response.ErrorCode.STUDY_NO
 import static com.campfiredev.growtogether.exception.response.ErrorCode.USER_NOT_APPLIED;
 import static com.campfiredev.growtogether.exception.response.ErrorCode.USER_NOT_FOUND;
 import static com.campfiredev.growtogether.study.entity.StudyStatus.COMPLETE;
+import static com.campfiredev.growtogether.study.entity.StudyStatus.RECRUIT;
 import static com.campfiredev.growtogether.study.type.StudyMemberType.KICK;
 import static com.campfiredev.growtogether.study.type.StudyMemberType.LEADER;
 import static com.campfiredev.growtogether.study.type.StudyMemberType.NORMAL;
@@ -16,13 +17,17 @@ import com.campfiredev.growtogether.exception.custom.CustomException;
 import com.campfiredev.growtogether.member.entity.MemberEntity;
 import com.campfiredev.growtogether.member.repository.MemberRepository;
 import com.campfiredev.growtogether.point.service.PointService;
+import com.campfiredev.growtogether.study.dto.join.JoinCreateDto;
+import com.campfiredev.growtogether.study.dto.join.JoinDetailsDto;
 import com.campfiredev.growtogether.study.dto.join.StudyMemberListDto;
 import com.campfiredev.growtogether.study.entity.Study;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
 import com.campfiredev.growtogether.study.repository.StudyRepository;
 import com.campfiredev.growtogether.study.repository.join.JoinRepository;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +40,7 @@ public class JoinService {
   private final MemberRepository memberRepository;
   private final StudyRepository studyRepository;
   private final PointService pointService;
+  private final RedisTemplate<String, Object> redisTemplate;
 
   /**
    * 참가 신청
@@ -42,7 +48,7 @@ public class JoinService {
    * @param memberId 로그인한 사용자 id
    * @param studyId  스터디 id
    */
-  public void join(Long memberId, Long studyId) {
+  public void join(Long memberId, Long studyId, JoinCreateDto joinCreateDto) {
     MemberEntity memberEntity = memberRepository.findById(memberId)
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -53,7 +59,11 @@ public class JoinService {
     validateJoin(memberEntity, studyEntity);
 
     // 참가 정보 저장
-    joinRepository.save(StudyMemberEntity.create(studyEntity, memberEntity));
+    StudyMemberEntity save = joinRepository.save(
+        StudyMemberEntity.create(studyEntity, memberEntity));
+
+    redisTemplate.opsForValue()
+        .set("join" + save.getId(), joinCreateDto.getContent(), 7, TimeUnit.DAYS);
 
     // 추후 참가 신청 메일 발송 로직 추가
   }
@@ -94,7 +104,20 @@ public class JoinService {
   }
 
   /**
+   * 참가신청 세부사항 조히
+   */
+  public JoinDetailsDto getJoin(Long studyMemberId){
+    StudyMemberEntity studyMemberEntity = joinRepository.findWithSkillsById(studyMemberId)
+        .orElseThrow(() -> new CustomException(USER_NOT_APPLIED));
+
+    String content = (String) redisTemplate.opsForValue().get("join" + studyMemberId);
+
+    return JoinDetailsDto.from(studyMemberEntity, content);
+  }
+
+  /**
    * 참여 신청자 리스트 조회
+   *
    * @param studyId 스터디 id
    * @return
    */
@@ -108,6 +131,7 @@ public class JoinService {
 
   /**
    * 참여자 리스트 조회(팀장(LEADER), 일반 멤버(NORMAL), 강퇴자(KICK))
+   *
    * @param studyId
    * @return
    */
@@ -160,7 +184,7 @@ public class JoinService {
    * @param studyEntity
    */
   private void validateJoin(MemberEntity memberEntity, Study studyEntity) {
-    if (COMPLETE.equals(studyEntity.getStudyStatus())) {
+    if (RECRUIT.equals(studyEntity.getStudyStatus())) {
       throw new CustomException(STUDY_FULL);
     }
 

--- a/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/schedule/ScheduleService.java
@@ -92,7 +92,7 @@ public class ScheduleService {
         continue;
       }
 
-      if (start.isAfter(schedule.getStart()) && start.isBefore(schedule.getEnd())) {
+      if (!(end.isBefore(schedule.getStart()) || start.isAfter(schedule.getEnd()))) {
         throw new CustomException(ALREADY_EXISTS_SCHEDULE);
       }
     }


### PR DESCRIPTION

## 📝 요약(Summary)
참가 신청 시 팀장에게 한마디 추가했습니다.
팀장에게 한마디는 redis에 저장하고 나중에 신청자 정보 확인 할 때 같이 리턴합니다.

신청자 정보 확인 JoinDetailsDto에 StudyMemberId도 같이 넘기도록 했습니다.

일정 변경 시 메인 일정과 겹치는지 확인하는 로직을 변경했습니다.

출석 시  현재 시간 +-10 이내에 메인 일정이 있는지 확인하는 로직을 해당 스터디에서만 조회하도록 수정했습니다. 

채팅 소켓 연결 시 jwt인증 로직을 변경했습니다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->