### PR TITLE
feat :  특정 인원에게만 채팅, 참가 신청 시 알림

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/chat/ChatManager.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/ChatManager.java
@@ -1,0 +1,113 @@
+package com.campfiredev.growtogether.chat;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ChatManager {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  private final Map<String, String> sessionToUsername = new ConcurrentHashMap<>();
+  private final Map<String, List<String>> usernameToSessions = new ConcurrentHashMap<>();
+
+  @EventListener
+  public void handleWebSocketConnectListener(SessionConnectEvent event) {
+    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+    String authorization = headerAccessor.getFirstNativeHeader("Authorization");
+    String studyId = headerAccessor.getFirstNativeHeader("studyId");
+    String username = headerAccessor.getFirstNativeHeader("username");
+
+    redisTemplate.opsForSet().add("chatRoom" + studyId, username);
+
+    String sessionId = headerAccessor.getSessionId();
+    registerSession(sessionId, username);
+
+    headerAccessor.getSessionAttributes().put("username", username);
+    headerAccessor.getSessionAttributes().put("studyId", studyId);
+
+    sendParticipants(studyId);
+  }
+
+  @EventListener
+  public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+    String sessionId = event.getSessionId();
+
+    String username = (String) headerAccessor.getSessionAttributes().get("username");
+    String studyId = (String) headerAccessor.getSessionAttributes().get("studyId");
+
+    System.out.println("username: " + username);
+
+    redisTemplate.opsForSet().remove("chatRoom" + studyId, username);
+
+    removeSession(sessionId);
+
+    sendParticipants(studyId);
+  }
+
+  public void sendDirectMessage(String username, String studyId, String message) {
+    List<String> sessionIds = getSessionIdsByUsername(username);
+    for (String sessionId : sessionIds) {
+      messagingTemplate.convertAndSendToUser(sessionId, "/queue/private/" + studyId, message);
+    }
+  }
+
+  private void sendEntryMessage(String studyId, String username) {
+    String message = username + "님이 채팅방에 입장하였습니다.";
+    messagingTemplate.convertAndSend("/topic/study/" + studyId + "/messages", message);
+  }
+
+  public Set<String> getParticipants(String studyId) {
+    String participantsKey = "chatRoom" + studyId;
+    return redisTemplate.opsForSet().members(participantsKey);
+  }
+
+  private void sendParticipants(String studyId) {
+    String participantsKey = "chatRoom" + studyId;
+    Set<String> participants = redisTemplate.opsForSet().members(participantsKey);
+    messagingTemplate.convertAndSend("/topic/study/" + studyId + "/participants", participants);
+  }
+
+  public void registerSession(String sessionId, String username) {
+    System.out.println("sessionId: " + sessionId + ", username: " + username);
+    sessionToUsername.put(sessionId, username);
+    usernameToSessions.putIfAbsent(username, new ArrayList<>());
+    usernameToSessions.get(username).add(sessionId);
+  }
+
+  public void removeSession(String sessionId) {
+    String username = sessionToUsername.remove(sessionId);
+    if (username != null) {
+      List<String> sessions = usernameToSessions.get(username);
+      if (sessions != null) {
+        sessions.remove(sessionId);
+        if (sessions.isEmpty()) {
+          usernameToSessions.remove(username);
+        }
+      }
+    }
+  }
+
+  public List<String> getSessionIdsByUsername(String username) {
+    return usernameToSessions.getOrDefault(username, Collections.emptyList());
+  }
+}
+
+

--- a/src/main/java/com/campfiredev/growtogether/chat/ChatMessageScheduler.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/ChatMessageScheduler.java
@@ -29,7 +29,7 @@ public class ChatMessageScheduler {
   private final ChatRepository chatMessageRepository;
   private final StudyRepository studyRepository;
 
-  @Scheduled(fixedRate = 60000)
+  //@Scheduled(fixedRate = 60000)
   public void persistOldMessages() {
 
     List<Study> studies = studyRepository.findByStudyStatus(PROGRESS);

--- a/src/main/java/com/campfiredev/growtogether/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/config/WebSocketConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -26,8 +27,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
-    registry.enableSimpleBroker("/topic");
+    registry.enableSimpleBroker("/topic", "/queue");
     registry.setApplicationDestinationPrefixes("/app");
+    registry.setUserDestinationPrefix("/user");
   }
 
   @Override

--- a/src/main/java/com/campfiredev/growtogether/chat/controller/ChatController.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/controller/ChatController.java
@@ -1,20 +1,28 @@
 package com.campfiredev.growtogether.chat.controller;
 
+import com.campfiredev.growtogether.chat.ChatManager;
 import com.campfiredev.growtogether.chat.dto.ChatMessageDto;
 import com.campfiredev.growtogether.chat.dto.SliceMessageDto;
 import com.campfiredev.growtogether.chat.service.ChatService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,13 +36,11 @@ public class ChatController {
   private final ChatService chatService;
   private final RedisTemplate<String, Object> redisTemplate;
   private final ObjectMapper objectMapper;
+  private final ChatManager chatManager;
+  private final SimpMessagingTemplate messagingTemplate;
 
   @MessageMapping("/study/{studyId}/send")
-  @SendTo("/topic/study/{studyId}")
-  public ChatMessageDto sendMessage(@DestinationVariable String studyId,
-      @Payload ChatMessageDto chatMessageDto) {
-    log.info(chatMessageDto.getMessage());
-
+  public void sendMessage(@DestinationVariable String studyId, @Payload ChatMessageDto chatMessageDto) {
     chatMessageDto.setDate(LocalDateTime.now());
 
     try {
@@ -43,34 +49,36 @@ public class ChatController {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
-    return chatMessageDto;
+
+    if (chatMessageDto.getTo() != null && !chatMessageDto.getTo().isEmpty()) {
+      Set<String> recipients = new HashSet<>(chatMessageDto.getTo());
+      recipients.add(chatMessageDto.getSender());
+
+      for (String recipient : recipients) {
+        sendDirectMessage(recipient, studyId, chatMessageDto);
+      }
+    } else {
+      messagingTemplate.convertAndSend("/topic/study/" + studyId, chatMessageDto);
+    }
   }
 
-  @MessageMapping("/study/{studyId}/enter")
-  @SendTo("/topic/study/{studyId}")
-  public ChatMessageDto enterChat(@DestinationVariable String studyId,
-      @Payload ChatMessageDto chatMessageDto,
-      @Header("simpSessionAttributes") Map<String, Object> sessionAttributes) {
 
-    String username = (String) sessionAttributes.get("username");
-    chatMessageDto.setMessage(username + "님이 입장하였습니다.");
-
-    log.info(chatMessageDto.getMessage());
-
-    return chatMessageDto;
+  public void sendDirectMessage(String username, String studyId, ChatMessageDto message) {
+    List<String> sessionIds = chatManager.getSessionIdsByUsername(username);
+    for (String sessionId : sessionIds) {
+      SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+      headerAccessor.setSessionId(sessionId);
+      headerAccessor.setLeaveMutable(true);
+      messagingTemplate.convertAndSendToUser(sessionId, "/queue/private/" + studyId, message,headerAccessor.getMessageHeaders());
+    }
   }
 
-  @MessageMapping("/study/{studyId}/exit")
-  @SendTo("/topic/study/{studyId}")
-  public ChatMessageDto exitChat(@DestinationVariable String studyId,
-      @Payload ChatMessageDto chatMessageDto) {
-    chatMessageDto.setMessage(chatMessageDto.getSender() + "님이 퇴장하셨습니다.");
-    chatMessageDto.setDate(LocalDateTime.now());
-
-    log.info(chatMessageDto.getMessage());
-
-    return chatMessageDto;
+  @MessageMapping("/study/{studyId}/participants")
+  public void sendParticipants(@DestinationVariable String studyId) {
+    Set<String> participants = chatManager.getParticipants(studyId);
+    messagingTemplate.convertAndSend("/topic/study/" + studyId + "/participants", participants);
   }
+
 
   @GetMapping("/study/{studyId}/chat")
   public SliceMessageDto getChatMessages(@PathVariable Long studyId,

--- a/src/main/java/com/campfiredev/growtogether/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/dto/ChatMessageDto.java
@@ -1,6 +1,7 @@
 package com.campfiredev.growtogether.chat.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,5 +24,7 @@ public class ChatMessageDto {
   private String imageUrl;
 
   private LocalDateTime date;
+
+  private List<String> to;
 
 }

--- a/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
@@ -1,6 +1,7 @@
 package com.campfiredev.growtogether.chat.service;
 
 import com.campfiredev.growtogether.member.util.JwtUtil;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -24,6 +25,8 @@ public class JwtInterceptor implements ChannelInterceptor {
 
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
       String token = accessor.getFirstNativeHeader("Authorization");
+      String studyId = accessor.getFirstNativeHeader("studyId");
+      String username = accessor.getFirstNativeHeader("username");
 
       if (token == null || !token.startsWith("Bearer ")) {
         throw new IllegalArgumentException("JWT 토큰이 필요합니다.");
@@ -35,7 +38,13 @@ public class JwtInterceptor implements ChannelInterceptor {
 
       log.info("jwt 검증 로직 추가할 예정");
 
-      accessor.getSessionAttributes().put("username", "임시 닉네임");
+      System.out.println(studyId);
+      Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+      System.out.println(sessionAttributes);
+
+      accessor.getSessionAttributes().put("studyId", studyId);
+
+      System.out.println(sessionAttributes);
     }
 
     return message;

--- a/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
@@ -31,7 +31,7 @@ public class JoinController {
    */
   @PostMapping("{studyId}/join")
   public void join(@PathVariable Long studyId, @RequestBody JoinCreateDto joinCreateDto) {
-    joinService.join(5L,studyId, joinCreateDto);
+    joinService.join(6L,studyId, joinCreateDto);
   }
 
   /**

--- a/src/main/java/com/campfiredev/growtogether/study/repository/join/JoinRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/study/repository/join/JoinRepository.java
@@ -52,5 +52,7 @@ public interface JoinRepository extends JpaRepository<StudyMemberEntity, Long> {
       + "JOIN FETCH sm.member "
       + "WHERE sm.id IN :ids")
   List<StudyMemberEntity> findAllWithMembersInIds(@Param("ids") List<Long> ids);
+
+
 }
 

--- a/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
@@ -6,6 +6,7 @@ import static com.campfiredev.growtogether.exception.response.ErrorCode.STUDY_FU
 import static com.campfiredev.growtogether.exception.response.ErrorCode.STUDY_NOT_FOUND;
 import static com.campfiredev.growtogether.exception.response.ErrorCode.USER_NOT_APPLIED;
 import static com.campfiredev.growtogether.exception.response.ErrorCode.USER_NOT_FOUND;
+import static com.campfiredev.growtogether.notification.type.NotiType.STUDY;
 import static com.campfiredev.growtogether.study.entity.StudyStatus.COMPLETE;
 import static com.campfiredev.growtogether.study.entity.StudyStatus.RECRUIT;
 import static com.campfiredev.growtogether.study.type.StudyMemberType.KICK;
@@ -16,6 +17,7 @@ import static com.campfiredev.growtogether.study.type.StudyMemberType.PENDING;
 import com.campfiredev.growtogether.exception.custom.CustomException;
 import com.campfiredev.growtogether.member.entity.MemberEntity;
 import com.campfiredev.growtogether.member.repository.MemberRepository;
+import com.campfiredev.growtogether.notification.service.NotificationService;
 import com.campfiredev.growtogether.point.service.PointService;
 import com.campfiredev.growtogether.study.dto.join.JoinCreateDto;
 import com.campfiredev.growtogether.study.dto.join.JoinDetailsDto;
@@ -43,6 +45,7 @@ public class JoinService {
   private final StudyRepository studyRepository;
   private final PointService pointService;
   private final RedisTemplate<String, Object> redisTemplate;
+  private final NotificationService notificationService;
 
   /**
    * 참가 신청
@@ -68,6 +71,13 @@ public class JoinService {
         .set("join" + save.getId(), joinCreateDto.getContent(), 7, TimeUnit.DAYS);
 
     // 추후 참가 신청 메일 발송 로직 추가
+
+    List<StudyMemberEntity> find = joinRepository.findByStudyWithMembersInStatus(
+        studyId, List.of(LEADER));
+
+    StudyMemberEntity studyMemberEntity = find.get(0);
+
+    notificationService.sendNotification(studyMemberEntity.getMember(),"참가 신청함", null,STUDY);
   }
 
   /**


### PR DESCRIPTION

## 📝 요약(Summary)
특정인원에게만 채팅 보내기 구현
소켓 연결, 해제 시 이벤트 리스너에서 사용자 닉네임, sessionId를 받아 저장, 삭제합니다.
채팅 중 ChatMessageDto List<String> to 에 전달하고자 하는 사용자 닉네임이 들어오면
닉네임으로 해당 사용자들의 sessionId를 가져오고 이를 통해 해당 사용자들에게만 채팅이 전송되도록 구현했습니다.
지금은 소켓 연결 시 테스트용으로 직접 닉네임을 받지만 jwt 토큰에서 추출하는 것으로 변경할 예정입니다.

참가 신청 시 스터디 팀장에게 sse알림 
스터디 참가 신청 시 참가 신청 요청이 왔다고 스터디 팀장한테 알림이 가도록 했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->