### PR TITLE
fix(BootCamp): LazyInitializationException

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampReviewController.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampReviewController.java
@@ -14,8 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,8 +31,6 @@ public class BootCampReviewController {
 
     /**
      * 부트캠프 리뷰 등록
-     * @param request
-     * @return 성공메세지
      */
     @Operation(summary = "부트캠프 리뷰 등록", description = "새로운 부트캠프 리뷰를 등록합니다.")
     @ApiResponses({
@@ -51,9 +47,6 @@ public class BootCampReviewController {
 
     /**
      * 부트캠프 리뷰 수정
-     * @param bootCampId
-     * @param request
-     * @return
      */
     @Operation(summary = "부트캠프 리뷰 수정", description = "기존 부트캠프 리뷰를 수정합니다.")
     @ApiResponses({
@@ -69,8 +62,6 @@ public class BootCampReviewController {
 
     /**
      * 부트캠프 리뷰 삭제
-     * @param bootCampId
-     * @return
      */
     @Operation(summary = "부트캠프 리뷰 삭제", description = "특정 부트캠프 리뷰를 삭제합니다.")
     @ApiResponses({
@@ -165,7 +156,7 @@ public class BootCampReviewController {
     /**
      * 내가 좋아요한 게시글 모음
      */
-    @Operation(summary = "내가 좋아요한 부트캠프 리뷰 조회", description = "사용자가 좋아요한 부트캠프 리뷰 목록을 조회합니다.")
+/*    @Operation(summary = "내가 좋아요한 부트캠프 리뷰 조회", description = "사용자가 좋아요한 부트캠프 리뷰 목록을 조회합니다.")
     @GetMapping("/my/Likes")
     public ResponseEntity<BootCampReviewResponseDto.PageResponse> getLikedReviews(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -176,7 +167,7 @@ public class BootCampReviewController {
 
         BootCampReviewResponseDto.PageResponse likedReviews = bootCampReviewService.getLikeReviews(customUserDetails, pageable);
         return ResponseEntity.ok(likedReviews);
-    }
+    }*/
 
     @Operation(summary = "부트캠프 프로그램 과정 목록 조회", description = "프로그램 과정을 조회합니다.")
     @GetMapping("/programCourses")

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/dto/BootCampReviewResponseDto.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/dto/BootCampReviewResponseDto.java
@@ -2,10 +2,7 @@ package com.campfiredev.growtogether.bootcamp.dto;
 
 import com.campfiredev.growtogether.bootcamp.entity.BootCampReview;
 import com.campfiredev.growtogether.bootcamp.type.ProgramCourse;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
@@ -15,6 +12,7 @@ import java.util.stream.Collectors;
 
 public class BootCampReviewResponseDto {
 
+    @Setter
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -60,9 +58,9 @@ public class BootCampReviewResponseDto {
                     .programSatisfaction(review.getProgramSatisfaction())
                     .likeCount(review.getLikeCount())
                     .viewCount(review.getViewCount())
-                    .commentCount(review.getComments().size())
-                    .skillNames(skillNames)
                     .programCourse(review.getProgramCourse())
+                    .commentCount(review.getCommentCount())
+                    .skillNames(skillNames)
                     .createdAt(review.getCreatedAt())
                     .updatedAt(review.getUpdatedAt())
                     .build();

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampComment.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampComment.java
@@ -37,7 +37,7 @@ public class BootCampComment extends BaseEntity {
     @JoinColumn(name = "boot_camp_id",nullable = false)
     private BootCampReview bootCampReview;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id",nullable = false)
     private MemberEntity member;
 

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampReview.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampReview.java
@@ -63,7 +63,7 @@ public class BootCampReview extends BaseEntity {
     @OneToMany(mappedBy = "bootCampReview", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BootCampSkill> bootCampSkills;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id",nullable = false)
     private MemberEntity member;
 
@@ -73,6 +73,9 @@ public class BootCampReview extends BaseEntity {
 
     @OneToMany(mappedBy = "bootCampReview", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewLike> likes;
+
+    @Transient  // DB에는 저장되지 않지만, 조회 시 사용할 수 있도록 함
+    private int commentCount;
 
     public void increaseLikeCount(){
         this.likeCount++;

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/entity/ReviewLike.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/entity/ReviewLike.java
@@ -17,7 +17,7 @@ public class ReviewLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long likeId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id",nullable = false)
     private MemberEntity member;
 

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampCommentRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampCommentRepository.java
@@ -2,19 +2,24 @@ package com.campfiredev.growtogether.bootcamp.repository;
 
 
 import com.campfiredev.growtogether.bootcamp.entity.BootCampComment;
-import com.campfiredev.growtogether.bootcamp.entity.BootCampReview;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface BootCampCommentRepository extends JpaRepository<BootCampComment, Long> {
 
-    @Query("select c from BootCampComment c LEFT JOIN FETCH c.childComments where c.bootCampReview = :review AND c.parentComment IS NULL")
-    Page<BootCampComment> findTopLevelCommentsWithChildren(@Param("review") BootCampReview review, Pageable pageable);
+    //@Query("select c from BootCampComment c LEFT JOIN FETCH c.childComments where c.bootCampReview = :review AND c.parentComment IS NULL")
+   // Page<BootCampComment> findTopLevelCommentsWithChildren(@Param("review") BootCampReview review, Pageable pageable);
 
     boolean existsByBootCampCommentIdAndIsDeletedTrue(Long bootCampCommentId);
+
+    @Query("SELECT DISTINCT c FROM BootCampComment c " +
+            "LEFT JOIN FETCH c.childComments " +
+            "LEFT JOIN FETCH c.member " +
+            "WHERE c.bootCampReview.bootCampId =:bootCampId")
+    List<BootCampComment> findCommentsWithChildrenByBootCampId(@Param("bootCampId") Long bootCampId);
 }

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampReviewRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampReviewRepository.java
@@ -1,7 +1,6 @@
 package com.campfiredev.growtogether.bootcamp.repository;
 
 import com.campfiredev.growtogether.bootcamp.entity.BootCampReview;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface BootCampReviewRepository extends JpaRepository<BootCampReview, Long> {
 
-    Page<BootCampReview> findAll(Pageable pageable);
+    //Page<BootCampReview> findAll(Pageable pageable);
 
     @Query("SELECT DISTINCT b FROM BootCampReview b " +
             "LEFT JOIN FETCH b.bootCampSkills bs " +
@@ -26,5 +25,9 @@ public interface BootCampReviewRepository extends JpaRepository<BootCampReview, 
     + "LEFT JOIN FETCH bs.skill s" +
     " WHERE b.bootCampId = :bootCampId")
     Optional<BootCampReview> findByIdWithSkills(@Param("bootCampId")Long bootCampId);
+
+    @Query("SELECT br.bootCampId, COUNT(c) FROM BootCampReview br LEFT JOIN br.comments c " +
+            "WHERE br.bootCampId IN :bootCampIds GROUP BY br.bootCampId")
+    List<Object[]> findCommentCountsByBootCampIds(@Param("bootCampIds") List<Long> bootCampIds);
 
 }

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/service/BootCampCommentService.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/service/BootCampCommentService.java
@@ -14,10 +14,13 @@ import com.campfiredev.growtogether.notification.service.NotificationService;
 import com.campfiredev.growtogether.notification.type.NotiType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -114,12 +117,12 @@ public class BootCampCommentService {
         bootCampCommentRepository.save(comment);
     }
 
-
     public Page<BootCampComment> getComments(Long reviewId, Pageable pageable) {
-        BootCampReview review = bootCampReviewRepository.findById(reviewId)
+        bootCampReviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 
-        return bootCampCommentRepository.findTopLevelCommentsWithChildren(review, pageable);
+        List<BootCampComment> comments = bootCampCommentRepository.findCommentsWithChildrenByBootCampId(reviewId);
+        return new PageImpl<>(comments, pageable, comments.size());
     }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. pring.jpa.open-in-view=false 설정 시, 트랜잭션이 종료되면 영속성 컨텍스트가 닫히면서 Lazy 필드에 접근시 세션이 닫혀 있어서, LazyInitializationException 발생한 에러를 Fetch Join으로 수정

2. MultipleBagFetchException(JPA에서 여러 개의 List Fetch 불가)  두 개 이상의 List<>를 Fetch Join 하면 안되므로 쿼리를 나눠서 조회하는 방식으로 수정
(BootCampReviewRespositoryImpl)

3. FetchType.EAGER -> LAZY변경

4. 댓글 개수 `findCommentsWithChildrenByBootCampId` 에서는 모든 댓글을 다 조회하는 Fetch Join 방식으로 하였을시, 모든 댓글 데이터를 다 조회하여야 하는 문제, 중복 데이터 및 n+1 문제가 발생하여서필요할 때 개수만(Count)  조회하고 필요한 정보만 조회하는 방식으로 하였습니다. 
---------------------------------------------------------------

` Fetch Join 사용 시 발생 했었던 에러들 정리 `

- JPA는 List<>를 여러 개 동시에 Fetch Join 할 수 없음 
- 서브쿼리에서는 fetchJoin을 사용할 수 없음
- OneToMany 관계에서  fetchJoin을 사용하면 중복된 데이터가 반환될 위험이 있음 , 중복 데이터 제거를 위해 DISTINCT 사용
- OneToMany (List<>) Fetch Join 1개까지 가능(2개 이상일 시 MultipleBagFetchException)  , ManyToOne 가능 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
@focandlol @Oh-Myeongjae @try3982  
수정 할 부분 있으면 조언 해주시면 감사하겠습니다.  
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->