### PR TITLE
feat(BootCamp): 댓글 조회 , 게시글 조회

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampCommentController.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampCommentController.java
@@ -3,7 +3,6 @@ package com.campfiredev.growtogether.bootcamp.controller;
 import com.campfiredev.growtogether.bootcamp.dto.CommentRequest;
 import com.campfiredev.growtogether.bootcamp.dto.CommentResponseDto;
 import com.campfiredev.growtogether.bootcamp.dto.CommentUpdateRequest;
-import com.campfiredev.growtogether.bootcamp.entity.BootCampComment;
 import com.campfiredev.growtogether.bootcamp.service.BootCampCommentService;
 import com.campfiredev.growtogether.member.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,12 +12,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Bootcamp Comment", description = "부트캠프 리뷰 댓글 관련 API")
 @RestController
@@ -70,15 +68,16 @@ public class BootCampCommentController {
             @ApiResponse(responseCode = "200", description = "댓글 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommentResponseDto.class)))
     })
+
     @GetMapping("/{bootCampId}")
-    public ResponseEntity<CommentResponseDto.PageResponse> getComments(@PathVariable Long bootCampId , @RequestParam(defaultValue = "0") int page){
-        Pageable pageable = PageRequest.of(page, 10);
-        Page<BootCampComment> commentsPage = bootCampCommentService.getComments(bootCampId, pageable);
+    public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable Long bootCampId ,
+            @RequestParam(defaultValue = "0") Long lastIdx
+            , @RequestParam(defaultValue = "9") Long size){
 
-        // Page<CommentResponseDto> -> CommentResponseDto.PageResponse 변환
-        CommentResponseDto.PageResponse response = CommentResponseDto.PageResponse.fromEntityPage(commentsPage);
+        List<CommentResponseDto> comments = bootCampCommentService.getComments(bootCampId,lastIdx,size);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(comments);
+
     }
 
 }

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampReviewController.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/controller/BootCampReviewController.java
@@ -87,7 +87,7 @@ public class BootCampReviewController {
     })
     @GetMapping
     public ResponseEntity<BootCampReviewResponseDto.PageResponse> getBootCampReviews(
-            @RequestParam(defaultValue = "0") int page ,
+            @RequestParam(defaultValue = "1") int page ,
             @RequestParam(defaultValue = "new") String sortType){
 
         return ResponseEntity.ok(bootCampReviewService.getBootCampReviews(page,sortType));

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/dto/BootCampReviewResponseDto.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/dto/BootCampReviewResponseDto.java
@@ -54,6 +54,7 @@ public class BootCampReviewResponseDto {
                     .bootCampName(review.getBootCampName())
                     .startdate(review.getBootCampStartDate())
                     .enddate(review.getBootCampEndDate())
+                    .learningLevel(review.getLearningLevel())
                     .assistantSatisfaction(review.getAssistantSatisfaction())
                     .programSatisfaction(review.getProgramSatisfaction())
                     .likeCount(review.getLikeCount())
@@ -75,7 +76,7 @@ public class BootCampReviewResponseDto {
         private List<Response> reviews;
         private int totalPages;
         private int page;
-        private int totalElements;
+        private long totalElements;
         private int size;
 
         public static PageResponse fromEntityPage(Page<BootCampReview> bootCampReviews){
@@ -85,9 +86,9 @@ public class BootCampReviewResponseDto {
                             .map(Response::fromEntity)
                             .collect(Collectors.toList()))
                     .totalPages(bootCampReviews.getTotalPages())
-                    .page(bootCampReviews.getNumber())
-                    .totalElements(bootCampReviews.getNumberOfElements())
-                    .size(9)
+                    .page(bootCampReviews.getNumber()+1)
+                    .totalElements(bootCampReviews.getTotalElements())
+                    .size(bootCampReviews.getSize())
                     .build();
         }
     }

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/dto/CommentResponseDto.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/dto/CommentResponseDto.java
@@ -4,7 +4,9 @@ import com.campfiredev.growtogether.bootcamp.entity.BootCampComment;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Builder
@@ -28,7 +30,9 @@ public class CommentResponseDto {
                 .userId(comment.getMember().getMemberId())
                 .nickname(comment.getMember().getNickName())
                 .isDeleted(comment.getIsDeleted())
-                .childComments(comment.getChildComments().stream()
+                .childComments(Optional.ofNullable(comment.getChildComments())
+                        .orElse(Collections.emptyList())
+                        .stream()
                         .map(CommentResponseDto::fromEntity)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampComment.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/entity/BootCampComment.java
@@ -4,6 +4,7 @@ import com.campfiredev.growtogether.common.entity.BaseEntity;
 import com.campfiredev.growtogether.member.entity.MemberEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class BootCampComment extends BaseEntity {
     private BootCampComment parentComment;
 
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL,orphanRemoval = true)
+    @BatchSize(size = 10)
     private List<BootCampComment> childComments = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampCommentRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampCommentRepository.java
@@ -2,6 +2,7 @@ package com.campfiredev.growtogether.bootcamp.repository;
 
 
 import com.campfiredev.growtogether.bootcamp.entity.BootCampComment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,9 +13,6 @@ import java.util.List;
 @Repository
 public interface BootCampCommentRepository extends JpaRepository<BootCampComment, Long> {
 
-    //@Query("select c from BootCampComment c LEFT JOIN FETCH c.childComments where c.bootCampReview = :review AND c.parentComment IS NULL")
-   // Page<BootCampComment> findTopLevelCommentsWithChildren(@Param("review") BootCampReview review, Pageable pageable);
-
     boolean existsByBootCampCommentIdAndIsDeletedTrue(Long bootCampCommentId);
 
     @Query("SELECT DISTINCT c FROM BootCampComment c " +
@@ -22,4 +20,32 @@ public interface BootCampCommentRepository extends JpaRepository<BootCampComment
             "LEFT JOIN FETCH c.member " +
             "WHERE c.bootCampReview.bootCampId =:bootCampId")
     List<BootCampComment> findCommentsWithChildrenByBootCampId(@Param("bootCampId") Long bootCampId);
+
+    // 최초 요청 (부모 댓글만 가져오기)
+    @Query("""
+        SELECT c FROM BootCampComment c 
+        LEFT JOIN FETCH c.member
+        WHERE c.bootCampReview.bootCampId = :bootCampId 
+        AND c.depth = 0 
+        ORDER BY c.bootCampCommentId DESC
+        """)
+    List<BootCampComment> findParentComments(
+            @Param("bootCampId") Long bootCampId,
+            Pageable pageable
+    );
+
+    // lastIdx 이후 데이터만 가져오기 (무한 스크롤 요청)
+    @Query("""
+        SELECT c FROM BootCampComment c 
+        LEFT JOIN FETCH c.member 
+        WHERE c.bootCampReview.bootCampId = :bootCampId 
+        AND c.bootCampCommentId < :lastIdx 
+        AND c.depth = 0 
+        ORDER BY c.bootCampCommentId DESC
+        """)
+    List<BootCampComment> findParentCommentsWithLastIdx(
+            @Param("bootCampId") Long bootCampId,
+            @Param("lastIdx") Long lastIdx,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampReviewRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/bootcamp/repository/BootCampReviewRepository.java
@@ -1,6 +1,7 @@
 package com.campfiredev.growtogether.bootcamp.repository;
 
 import com.campfiredev.growtogether.bootcamp.entity.BootCampReview;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,12 +14,18 @@ import java.util.Optional;
 @Repository
 public interface BootCampReviewRepository extends JpaRepository<BootCampReview, Long> {
 
-    //Page<BootCampReview> findAll(Pageable pageable);
 
-    @Query("SELECT DISTINCT b FROM BootCampReview b " +
-            "LEFT JOIN FETCH b.bootCampSkills bs " +
-            "LEFT JOIN FETCH bs.skill ")
-    List<BootCampReview> findAllWithSkills(Pageable pageable);
+    @Query("SELECT b.bootCampId FROM BootCampReview b ORDER BY " +
+            "CASE WHEN :sortType = 'hot' THEN b.likeCount END DESC, " +
+            "CASE WHEN :sortType = 'new' THEN b.createdAt END DESC")
+    Page<Long> findBootCampReviewIdsBySortType(@Param("sortType") String sortType, Pageable pageable);
+
+    @Query("SELECT b FROM BootCampReview b " +
+            "LEFT JOIN FETCH b.member " + // 단건 관계는 문제없음
+            "LEFT JOIN FETCH b.bootCampSkills bs " +  // BootCampSkills 컬렉션 Fetch Join
+            "LEFT JOIN FETCH bs.skill " + // Skill도 Fetch Join
+            "WHERE b.bootCampId IN :ids")
+    List<BootCampReview> findAllByIdsWithDetails(@Param("ids") List<Long> ids);
 
     @Query("SELECT b FROM BootCampReview b "
     + "LEFT JOIN FETCH b.bootCampSkills bs "


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 댓글 무한 스크롤 기능 으로 수정
2. 부트캠프 게시글 조회시,
`HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory ` 에러 해결
 -> 페치조인으로 페이징 처리를 하는게 원인이며 해결한 방식은 `(getBootCampReviews) 메서드`
 1) 첫 번째 쿼리 → ID 목록만 페이징 처리
 2) 두 번째 쿼리 → ID 목록을 이용한 Fetch Join 조회
 3)  ID의 순서를 유지하도록 정렬 적용

4. totalElement 개수 정상화 , page는 1로 시작으로 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
@focandlol @Oh-Myeongjae @try3982 
페치조인으로 페이징 처리해서 HHH90003004 에러난걸 뒤늦게 확인해서, 고쳤습니다. 원래 어떤 방향으로 하는게 맞는걸까요?
조회기능이 너무 어렵게 가는것 같아요...
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->