### PR TITLE
포인트 내역 조회 API

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/common/config/SecurityConfig.java
+++ b/src/main/java/com/campfiredev/growtogether/common/config/SecurityConfig.java
@@ -90,10 +90,14 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
        // configuration.setAllowedOrigins(List.of("https://jiangxy.github.io","http://localhost:3000"));
-        configuration.setAllowedOrigins(List.of("https://jiangxy.github.io","http://localhost:5173"));
+      //  configuration.setAllowedOriginPatterns(List.of("https://jiangxy.github.io", "http://localhost:*"));
+       // configuration.setAllowedOriginPatterns(List.of("https://jiangxy.github.io", "http://localhost:*"));
+        //onfiguration.setAllowedOrigins(List.of("https://jiangxy.github.io","http://localhost:5173"));
+        configuration.setAllowedOriginPatterns(List.of("https://jiangxy.github.io", "http://localhost:*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setExposedHeaders(List.of("Authorization")); //Authorization 헤더를 노출하여 프론트엔드에서 접근할 수 있도록 설정
+        configuration.setExposedHeaders(List.of("Authorization", "Access-Token-Expire-Time"));
+     //   configuration.setExposedHeaders(List.of("Authorization")); //Authorization 헤더를 노출하여 프론트엔드에서 접근할 수 있도록 설정
       //  configuration.setExposedHeaders(List.of("Set-Cookie","loggedUser","authorization","Access-Token-Expire-Time","authentication"));
         configuration.setAllowCredentials(true);
 

--- a/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
+++ b/src/main/java/com/campfiredev/growtogether/exception/response/ErrorCode.java
@@ -47,7 +47,11 @@ public enum ErrorCode {
   FILE_SIZE_EXCEEDED("파일 크기 제한을 초과했습니다.", HttpStatus.PAYLOAD_TOO_LARGE),
   UNSUPPORTED_FILE_TYPE("지원되지 않는 파일 형식입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
   FILE_STORAGE_ERROR("파일 저장 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  FILE_DELETE_FAILED ("프로필 이미지 삭제 중 서버 오류 발생했습니다",HttpStatus.INTERNAL_SERVER_ERROR),
 
+
+  FILE_NOT_FOUND("삭제할 프로필 이미지가 없습니다.", HttpStatus.BAD_REQUEST),
+  PROFILE_IMAGE_NOT_FOUND("사용자의 프로필 이미지가 없습니다.", HttpStatus.BAD_REQUEST),
   //jwt exception
   NOT_VALID_TOKEN("토큰이 유효하지 않습니다.", UNAUTHORIZED),
   EXPIRED_TOKEN("토큰이 만료되었습니다.", UNAUTHORIZED),

--- a/src/main/java/com/campfiredev/growtogether/member/controller/ProfileController.java
+++ b/src/main/java/com/campfiredev/growtogether/member/controller/ProfileController.java
@@ -1,8 +1,11 @@
 package com.campfiredev.growtogether.member.controller;
 
+import com.campfiredev.growtogether.exception.custom.CustomException;
+import com.campfiredev.growtogether.exception.response.ErrorCode;
 import com.campfiredev.growtogether.member.service.MemberService;
 import com.campfiredev.growtogether.member.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,25 +32,68 @@ public class ProfileController {
         String fileUrl = s3Service.getFileUrl(fileKey);
         return ResponseEntity.ok(Map.of("profileImageUrl", fileUrl));
     }
+
     // 사용자 ID로 프로필 이미지 조회
     @GetMapping("/image/{memberId}")
-    public ResponseEntity<?> getProfileImageBymemberId(@PathVariable Long memberId) {
-        String fileUrl = memberService.getProfileImageUrl(memberId);
-        return ResponseEntity.ok(Map.of("profileImageUrl", fileUrl));
-    }
-    // 프로필 이미지 삭제
-    @DeleteMapping("image/delete")
-    public ResponseEntity<?> deleteProfileImage(@RequestParam("memberId") Long memberId) {
-        memberService.deleteProfileImage(memberId);
-        return ResponseEntity.ok(Map.of("message", "프로필 이미지가 삭제되었습니다."));
-    }
+    public ResponseEntity<?> getProfileImageByMemberId(@PathVariable Long memberId) {
+        try {
+            // 프로필 이미지 조회
+            String fileUrl = memberService.getProfileImageUrl(memberId);
+            return ResponseEntity.ok(Map.of("profileImageUrl", fileUrl));
 
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getErrorCode().getStatus())
+                    .body(Map.of("errorCode", e.getErrorCode().name(), "message", e.getMessage()));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("errorCode", ErrorCode.FILE_STORAGE_ERROR.name(),
+                            "message", "프로필 이미지 조회 중 예상치 못한 오류가 발생했습니다."));
+        }
+    }
+    // 프로필 이미지 업데이트
     @PutMapping("image/update")
     public ResponseEntity<?> updateProfileImage(
             @RequestParam("memberId") Long memberId,
             @RequestPart("profileImage") MultipartFile profileImage) {
 
-        String newImageKey = memberService.updateProfileImage(memberId, profileImage);
-        return ResponseEntity.ok(Map.of("message", "프로필 이미지가 업데이트되었습니다.", "imageKey", newImageKey));
+        try {
+            // 프로필 이미지 업데이트 후, S3 URL 반환
+            String newImageUrl = memberService.updateProfileImage(memberId, profileImage);
+
+            return ResponseEntity.ok(Map.of(
+                    "message", "프로필 이미지가 업데이트되었습니다.",
+                    "imageUrl", newImageUrl
+            ));
+
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getErrorCode().getStatus())
+                    .body(Map.of("errorCode", e.getErrorCode().name(), "message", e.getMessage()));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("errorCode", ErrorCode.FILE_UPLOAD_FAILED.name(),
+                            "message", "프로필 이미지 업데이트 중 예상치 못한 오류가 발생했습니다."));
+        }
     }
+
+    @DeleteMapping("image/delete")
+    public ResponseEntity<?> deleteProfileImage(@RequestParam("memberId") Long memberId) {
+        try {
+            // 프로필 이미지 삭제 요청
+            memberService.deleteProfileImage(memberId);
+            return ResponseEntity.ok(Map.of("message", "프로필 이미지가 삭제되었습니다."));
+
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getErrorCode().getStatus())
+                    .body(Map.of("errorCode", e.getErrorCode().name(), "message", e.getMessage()));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("errorCode", ErrorCode.FILE_DELETE_FAILED.name(),
+                            "message", "프로필 이미지 삭제 중 예상치 못한 오류가 발생했습니다."));
+        }
+    }
+
+
 }

--- a/src/main/java/com/campfiredev/growtogether/point/controller/PointTransactionController.java
+++ b/src/main/java/com/campfiredev/growtogether/point/controller/PointTransactionController.java
@@ -1,0 +1,43 @@
+package com.campfiredev.growtogether.point.controller;
+
+import com.campfiredev.growtogether.point.dto.PointHistoryResponseDto;
+import com.campfiredev.growtogether.point.entity.PointTransaction;
+import com.campfiredev.growtogether.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/points")
+@RequiredArgsConstructor
+public class PointTransactionController {
+
+    private final PointService pointService;
+
+    //  포인트 내역 조회 API
+    @GetMapping("/history")
+    public ResponseEntity<PointHistoryResponseDto> getPointHistory(@RequestParam Long memberId) {
+        return ResponseEntity.ok(pointService.getPointHistory(memberId));
+    }
+
+    // 포인트 사용 API
+    @PostMapping("/use")
+    public ResponseEntity<String> usePoint(@RequestParam Long memberId, @RequestParam int amount) {
+        pointService.usePoint(memberId, amount);
+        return ResponseEntity.ok("포인트 사용 성공");
+    }
+
+    // 포인트 적립 API
+    @PostMapping("/add")
+    public ResponseEntity<String> addPoint(@RequestParam Long memberId, @RequestParam int amount) {
+        pointService.addPoint(memberId, amount, PointTransaction.TransactionType.REWARD);
+        return ResponseEntity.ok("포인트 적립 성공");
+    }
+
+    //  포인트 충전 API
+    @PostMapping("/charge")
+    public ResponseEntity<String> chargePoint(@RequestParam Long memberId, @RequestParam int amount) {
+        pointService.addPoint(memberId, amount, PointTransaction.TransactionType.CHARGE);
+        return ResponseEntity.ok("포인트 충전 성공");
+    }
+}

--- a/src/main/java/com/campfiredev/growtogether/point/dto/PointHistoryResponseDto.java
+++ b/src/main/java/com/campfiredev/growtogether/point/dto/PointHistoryResponseDto.java
@@ -1,0 +1,21 @@
+package com.campfiredev.growtogether.point.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PointHistoryResponseDto {
+    private int availablePoints;
+    private List<PointHistoryItem> history;
+
+    @Getter
+    @AllArgsConstructor
+    public static class PointHistoryItem {
+        private String date;
+        private String type;
+        private String amount;
+    }
+}

--- a/src/main/java/com/campfiredev/growtogether/point/entity/PointTransaction.java
+++ b/src/main/java/com/campfiredev/growtogether/point/entity/PointTransaction.java
@@ -1,0 +1,39 @@
+package com.campfiredev.growtogether.point.entity;
+
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "point_transaction")
+public class PointTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @Column(nullable = false)
+    private LocalDateTime date; // 발생일자
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TransactionType type; // 거래 유형 (적립, 사용, 충전)
+
+    @Column(nullable = false)
+    private Integer amount; // 포인트 금액
+
+    // 거래 유형 Enum
+    public enum TransactionType {
+        REWARD, USE,CHARGE
+    }
+}

--- a/src/main/java/com/campfiredev/growtogether/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/point/repository/PointTransactionRepository.java
@@ -1,0 +1,11 @@
+package com.campfiredev.growtogether.point.repository;
+
+import com.campfiredev.growtogether.point.entity.PointTransaction;
+import com.campfiredev.growtogether.member.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+    List<PointTransaction> findByMemberOrderByDateDesc(MemberEntity member);
+}

--- a/src/main/java/com/campfiredev/growtogether/point/service/PointService.java
+++ b/src/main/java/com/campfiredev/growtogether/point/service/PointService.java
@@ -1,49 +1,106 @@
 package com.campfiredev.growtogether.point.service;
 
-import com.campfiredev.growtogether.common.annotation.RedissonLock;
 import com.campfiredev.growtogether.exception.custom.CustomException;
 import com.campfiredev.growtogether.exception.response.ErrorCode;
 import com.campfiredev.growtogether.member.entity.MemberEntity;
 import com.campfiredev.growtogether.member.repository.MemberRepository;
+import com.campfiredev.growtogether.point.dto.PointHistoryResponseDto;
+import com.campfiredev.growtogether.point.entity.PointTransaction;
+import com.campfiredev.growtogether.point.repository.PointTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.campfiredev.growtogether.exception.response.ErrorCode.INSUFFICIENT_POINTS;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PointService {
 
     private final MemberRepository memberRepository;
-
+    private final PointTransactionRepository pointTransactionRepository;
     private final Map<String, LocalDate> lastLoginMap;
 
-    @Transactional
+    // 포인트 사용
     public void usePoint(Long memberId, int amount) {
-        MemberEntity MemberEntity = memberRepository.findByIdWithLock(memberId)
+        MemberEntity member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (MemberEntity.getPoints() < amount) {
+        if (member.getPoints() < amount) {
             throw new CustomException(INSUFFICIENT_POINTS);
         }
 
-         MemberEntity.usePoints(amount);
+        // 포인트 차감
+        member.setPoints(member.getPoints() - amount);
+        memberRepository.save(member);
+
+        // 포인트 거래 내역 저장
+        PointTransaction transaction = PointTransaction.builder()
+                .member(member)
+                .date(LocalDateTime.now())
+                .type(PointTransaction.TransactionType.USE)
+                .amount(amount)
+                .build();
+        pointTransactionRepository.save(transaction);
     }
 
- //   @RedissonLock(key = "point:#{#memberId}", waitTime = 5, leaseTime = 10)
+    // 포인트 적립
+    public void addPoint(Long memberId, int amount, PointTransaction.TransactionType type) {
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 포인트 추가
+        member.setPoints(member.getPoints() + amount);
+        memberRepository.save(member);
+
+        // 포인트 거래 내역 저장
+        PointTransaction transaction = PointTransaction.builder()
+                .member(member)
+                .date(LocalDateTime.now())
+                .type(type)
+                .amount(amount)
+                .build();
+        pointTransactionRepository.save(transaction);
+    }
+
+    //  로그인 시 포인트 추가
     public void updatePoint(MemberEntity memberEntity, int point) {
         LocalDate today = LocalDate.now();
         String email = memberEntity.getEmail();
         LocalDate lastLoginDate = lastLoginMap.getOrDefault(email, null);
 
         if (lastLoginDate != null && lastLoginDate.equals(today)) return;
+
         memberEntity.setPoints(memberEntity.getPoints() + point);
+        memberRepository.save(memberEntity);
         lastLoginMap.put(email, today);
     }
 
+    // 포인트 내역 조회
+    public PointHistoryResponseDto getPointHistory(Long memberId) {
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 현재 사용 가능한 포인트
+        int availablePoints = member.getPoints();
+
+        // 포인트 거래 내역 조회
+        List<PointHistoryResponseDto.PointHistoryItem> history = pointTransactionRepository.findByMemberOrderByDateDesc(member)
+                .stream()
+                .map(tx -> new PointHistoryResponseDto.PointHistoryItem(
+                        tx.getDate().toLocalDate().toString(), // 날짜 형식 변환
+                        tx.getType().name(),
+                        (tx.getType() == PointTransaction.TransactionType.USE ? "-" : "+") + tx.getAmount()
+                ))
+                .collect(Collectors.toList());
+
+        return new PointHistoryResponseDto(availablePoints, history);
+    }
 }


### PR DESCRIPTION


<!--- ex) #이슈번호, #이슈번호 -->



## 📝 요약(Summary)
1. 구현 내용
- 사용자의 포인트 거래 내역을 조회하는 API를 구현하였습니다.
- memberId를 기반으로 point_transaction 테이블에서 데이터를 가져옵니다.
- 조회 가능한 포인트 내역:
    적립 (REWARD) 
    사용 (USE)
   충전 (CHARGE)
2. 주요 변경 사항
PointTransaction 엔티티 생성 (point_transaction 테이블)
포인트 내역 조회 API 추가 (GET /api/points/history)
포인트 서비스 (PointService)에서 거래 내역 조회 로직 구현
PointTransactionDto 추가 (응답 데이터 구조 정의)

3. SecurityConfig
- JWT 인증이 필요한 API 요청에서 CORS 문제를 해결하기 위해 아래 사항을 수정했습니다.
   - setAllowedOrigins() 제거 → setAllowedOriginPatterns()만 사용하여 포트 변경 대응 가능하도록 수정

   
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->