### PR TITLE
refactor: 채팅 리팩토링

### DIFF
--- a/src/main/java/com/campfiredev/growtogether/chat/ChatManager.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/ChatManager.java
@@ -46,8 +46,6 @@ public class ChatManager {
 
     headerAccessor.getSessionAttributes().put("username", username);
     headerAccessor.getSessionAttributes().put("studyId", studyId);
-    System.out.println("event");
-    System.out.println("username" + username);
 
     sendParticipants(studyId);
   }
@@ -59,8 +57,6 @@ public class ChatManager {
 
     String username = (String) headerAccessor.getSessionAttributes().get("username");
     String studyId = (String) headerAccessor.getSessionAttributes().get("studyId");
-
-    System.out.println("username: " + username);
 
     redisTemplate.opsForSet().remove("chatRoom" + studyId, username);
 
@@ -93,7 +89,6 @@ public class ChatManager {
   }
 
   public void registerSession(String sessionId, String username) {
-    System.out.println("sessionId: " + sessionId + ", username: " + username);
     sessionToUsername.put(sessionId, username);
     usernameToSessions.putIfAbsent(username, new ArrayList<>());
     usernameToSessions.get(username).add(sessionId);

--- a/src/main/java/com/campfiredev/growtogether/chat/controller/ChatController.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/controller/ChatController.java
@@ -44,8 +44,10 @@ public class ChatController {
     chatMessageDto.setDate(LocalDateTime.now());
 
     try {
-      redisTemplate.opsForList()
-          .leftPush("chat" + studyId, objectMapper.writeValueAsString(chatMessageDto));
+      if(chatMessageDto.getTo() == null || chatMessageDto.getTo().isEmpty()) {
+        redisTemplate.opsForList()
+            .leftPush("chat" + studyId, objectMapper.writeValueAsString(chatMessageDto));
+      }
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/campfiredev/growtogether/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/dto/ChatMessageDto.java
@@ -21,6 +21,8 @@ public class ChatMessageDto {
 
   private String message;
 
+  private Long studyMemberId;
+
   private String imageUrl;
 
   private LocalDateTime date;

--- a/src/main/java/com/campfiredev/growtogether/chat/entity/ChatEntity.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/entity/ChatEntity.java
@@ -1,11 +1,16 @@
 package com.campfiredev.growtogether.chat.entity;
 
 import com.campfiredev.growtogether.common.entity.BaseEntity;
+import com.campfiredev.growtogether.study.entity.Study;
+import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -26,9 +31,13 @@ public class ChatEntity extends BaseEntity {
   @Column(name = "chat_id")
   private Long id;
 
-  private Long studyId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "study_id", nullable = false)
+  private Study study;
 
-  private String sender;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private StudyMemberEntity sender;
 
   private String message;
 

--- a/src/main/java/com/campfiredev/growtogether/chat/repository/ChatRepository.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/repository/ChatRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
-  List<ChatEntity> findByStudyIdAndDateBefore(Long studyId, LocalDateTime lastDate, Pageable pageable);
+  List<ChatEntity> findByStudy_StudyIdAndDateBefore(Long studyId, LocalDateTime lastDate, Pageable pageable);
 
-  List<ChatEntity> findByStudyIdAndIdLessThanOrderByIdDesc(Long studyId, Long lastIndex, Pageable pageable);
+  List<ChatEntity> findByStudy_StudyIdAndIdLessThanOrderByIdDesc(Long studyId, Long lastIndex, Pageable pageable);
 
 
 }

--- a/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
+++ b/src/main/java/com/campfiredev/growtogether/chat/service/JwtInterceptor.java
@@ -20,36 +20,18 @@ public class JwtInterceptor implements ChannelInterceptor {
 
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
-    log.info("presend");
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
       String token = accessor.getFirstNativeHeader("Authorization");
-      String studyId = accessor.getFirstNativeHeader("studyId");
-      String username = accessor.getFirstNativeHeader("username");
 
       if (token == null || !token.startsWith("Bearer ")) {
         throw new IllegalArgumentException("JWT 토큰이 필요합니다.");
       }
 
-      System.out.println("token before: " + token);
-
       token = token.substring(7);
 
-      System.out.println("token after: " + token);
-
-      boolean tokenValid = jwtUtil.isTokenValid(token);
-      System.out.println("token valid: " + tokenValid);
-
-      log.info("jwt 검증 로직 추가할 예정");
-
-      System.out.println(studyId);
-      Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-      System.out.println(sessionAttributes);
-
-      accessor.getSessionAttributes().put("studyId", studyId);
-
-      System.out.println(sessionAttributes);
+      jwtUtil.isTokenValid(token);
     }
 
     return message;

--- a/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
+++ b/src/main/java/com/campfiredev/growtogether/study/controller/join/JoinController.java
@@ -3,6 +3,7 @@ package com.campfiredev.growtogether.study.controller.join;
 import com.campfiredev.growtogether.member.dto.CustomUserDetails;
 import com.campfiredev.growtogether.study.dto.join.JoinCreateDto;
 import com.campfiredev.growtogether.study.dto.join.JoinDetailsDto;
+import com.campfiredev.growtogether.study.dto.join.StudyMemberInfoDto;
 import com.campfiredev.growtogether.study.dto.join.StudyMemberListDto;
 import com.campfiredev.growtogether.study.service.join.JoinService;
 import com.campfiredev.growtogether.study.type.StudyMemberType;
@@ -84,6 +85,12 @@ public class JoinController {
   public List<StudyMemberListDto> studyMemberListFeedback(
       @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long studyId) {
     return joinService.getStudyMemberForFeedback(studyId, customUserDetails.getMemberId());
+  }
+
+  @GetMapping("/{studyId}/studyMember_info")
+  public StudyMemberInfoDto getStudyMemberInfo(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable Long studyId){
+    return joinService.getStudyMemberInfo(customUserDetails.getMemberId(),studyId);
   }
 }
 

--- a/src/main/java/com/campfiredev/growtogether/study/dto/join/StudyMemberInfoDto.java
+++ b/src/main/java/com/campfiredev/growtogether/study/dto/join/StudyMemberInfoDto.java
@@ -1,0 +1,16 @@
+package com.campfiredev.growtogether.study.dto.join;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StudyMemberInfoDto {
+
+  private String nickName;
+  private Long studyMemberId;
+}

--- a/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
+++ b/src/main/java/com/campfiredev/growtogether/study/service/join/JoinService.java
@@ -7,6 +7,7 @@ import com.campfiredev.growtogether.notification.service.NotificationService;
 import com.campfiredev.growtogether.point.service.PointService;
 import com.campfiredev.growtogether.study.dto.join.JoinCreateDto;
 import com.campfiredev.growtogether.study.dto.join.JoinDetailsDto;
+import com.campfiredev.growtogether.study.dto.join.StudyMemberInfoDto;
 import com.campfiredev.growtogether.study.dto.join.StudyMemberListDto;
 import com.campfiredev.growtogether.study.entity.Study;
 import com.campfiredev.growtogether.study.entity.join.StudyMemberEntity;
@@ -70,12 +71,12 @@ public class JoinService {
 
     StudyMemberEntity studyMemberEntity = find.get(0);
 
-    notificationService.sendNotification(studyMemberEntity.getMember(),memberEntity.getNickName() + "님이 참가 신청했습니다.", null,STUDY);
+    notificationService.sendNotification(studyMemberEntity.getMember(),
+        memberEntity.getNickName() + "님이 참가 신청했습니다.", null, STUDY);
   }
 
   /**
    * 참가 신청 확정 로그인 구현 이후 현재 로그인 한 사용자 정보도 받을 예정
-   *
    */
   public void confirmJoin(Long memberId, Long studyMemberId) {
     StudyMemberEntity studyMemberEntity = joinRepository.findWithStudyAndMemberById(studyMemberId)
@@ -86,9 +87,9 @@ public class JoinService {
     studyMemberEntity.confirm();
 
     Study study = studyMemberEntity.getStudy();
-    study.setParticipant(study.getParticipant()+1);
+    study.setParticipant(study.getParticipant() + 1);
 
-    if(Objects.equals(study.getMaxParticipant(), study.getParticipant())){
+    if (Objects.equals(study.getMaxParticipant(), study.getParticipant())) {
       study.setStudyStatus(PROGRESS);
     }
 
@@ -117,7 +118,7 @@ public class JoinService {
   /**
    * 참가신청 세부사항 조회
    */
-  public JoinDetailsDto getJoin(Long studyMemberId){
+  public JoinDetailsDto getJoin(Long studyMemberId) {
     StudyMemberEntity studyMemberEntity = joinRepository.findWithSkillsById(studyMemberId)
         .orElseThrow(() -> new CustomException(USER_NOT_APPLIED));
 
@@ -130,9 +131,7 @@ public class JoinService {
    * 참여 신청자 리스트 조회
    *
    * @param studyId 스터디 id
-   * @return
-   * 원하는 타입의 참여자 리스트 조회
-   * 팀장(LEADER), 일반 멤버(NORMAL), 참여 대기자(PENDING), 강퇴자(KICK)
+   * @return 원하는 타입의 참여자 리스트 조회 팀장(LEADER), 일반 멤버(NORMAL), 참여 대기자(PENDING), 강퇴자(KICK)
    */
   public List<StudyMemberListDto> getStudyMember(Long studyId, List<StudyMemberType> types) {
 
@@ -143,8 +142,7 @@ public class JoinService {
   }
 
   /**
-   * 피드백용 참여자 리스트 조회
-   * 자기 자신 제외
+   * 피드백용 참여자 리스트 조회 자기 자신 제외
    */
   public List<StudyMemberListDto> getStudyMemberForFeedback(Long studyId, Long memberId) {
 
@@ -156,6 +154,15 @@ public class JoinService {
         .collect(Collectors.toList());
 
     return getStudyMemberListDtos(studyMemberList);
+  }
+
+  public StudyMemberInfoDto getStudyMemberInfo(Long memberId, Long studyId) {
+    StudyMemberEntity studyMemberEntity = joinRepository.findByMember_MemberIdAndStudy_StudyId(
+            memberId, studyId)
+        .orElseThrow(() -> new CustomException(NOT_A_STUDY_MEMBER));
+
+    return new StudyMemberInfoDto(studyMemberEntity.getMember().getNickName(),
+        studyMemberEntity.getId());
   }
 
   /**
@@ -173,7 +180,8 @@ public class JoinService {
             memberId, studyMemberEntity.getStudy().getStudyId())
         .orElseThrow(() -> new CustomException(NOT_A_STUDY_MEMBER));
 
-    if(!studyMemberEntity.getMember().getMemberId().equals(loginUser.getMember().getMemberId()) && !LEADER.equals(loginUser.getStatus())){
+    if (!studyMemberEntity.getMember().getMemberId().equals(loginUser.getMember().getMemberId())
+        && !LEADER.equals(loginUser.getStatus())) {
       throw new CustomException(CANCEL_PERMISSION_DENIED);
     }
 
@@ -190,11 +198,13 @@ public class JoinService {
     }
 
     //현재 로그인 한 사용자 정보 가져와서 해당 스터디 팀장인지 확인
-    joinRepository.findByMember_MemberIdAndStudy_StudyIdAndStatusIn(memberId, studyMemberEntity.getStudy().getStudyId(), List.of(LEADER))
+    joinRepository.findByMember_MemberIdAndStudy_StudyIdAndStatusIn(memberId,
+            studyMemberEntity.getStudy().getStudyId(), List.of(LEADER))
         .orElseThrow(() -> new CustomException(TEAM_LEADER_ONLY_CONFIRMATION));
 
     //스터디에 이미 참여인원이 꽉찼으면 신청 받지 않음
-    if(studyMemberEntity.getStudy().getMaxParticipant() <= studyMemberEntity.getStudy().getParticipant()){
+    if (studyMemberEntity.getStudy().getMaxParticipant() <= studyMemberEntity.getStudy()
+        .getParticipant()) {
       throw new CustomException(STUDY_FULL);
     }
   }
@@ -216,7 +226,8 @@ public class JoinService {
         });
   }
 
-  private static List<StudyMemberListDto> getStudyMemberListDtos(List<StudyMemberEntity> studyMemberList) {
+  private static List<StudyMemberListDto> getStudyMemberListDtos(
+      List<StudyMemberEntity> studyMemberList) {
     return studyMemberList.stream()
         .map(studyMember -> StudyMemberListDto.fromEntity(studyMember))
         .collect(Collectors.toList());


### PR DESCRIPTION

## 📝 요약(Summary)
현재 로그인한 사용자의 해당 스터디의 studyMemberId 리턴 api 추가
ChatEntity 연관관계 설정
ChatMessageDto studyMemberId 필드 추가
ChatEntity 연관관계 설정에 따른 로직 변경
 - ChatMessageScheduler에서 sender에 studyMemberEntity 넣도록 변경
 - 이전 채팅 기록 조회 시 sender 현재 nickName으로 최신화 해서 리턴
heartbeat 설정
chatMessageScheduler 동작 시간 매일 24시로 변경
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->